### PR TITLE
Add missing #include of unistd.h required by gcc 4.7

### DIFF
--- a/src/cc/qcdio/QCFdPoll.cc
+++ b/src/cc/qcdio/QCFdPoll.cc
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
 
 #ifndef QC_OS_NAME_LINUX
 #   include <map>

--- a/src/cc/qcdio/QCThread.cc
+++ b/src/cc/qcdio/QCThread.cc
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <sched.h>
+#include <unistd.h>
 #endif
 
 class QCStartedThreadList

--- a/src/cc/tools/qfsdataverify_main.cc
+++ b/src/cc/tools/qfsdataverify_main.cc
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <iostream>
+#include <unistd.h>
 
 using std::cout;
 using std::cerr;

--- a/src/cc/tools/qfsshell_main.cc
+++ b/src/cc/tools/qfsshell_main.cc
@@ -34,6 +34,7 @@
 #include <map>
 #include <memory>
 #include <iomanip>
+#include <unistd.h>
 
 namespace KFS
 {


### PR DESCRIPTION
Building with gcc 4.7 (the default in Ubuntu 12.10) fails with the following  errors due to unistd.h not being included:

```
/home.local/trobinson/qfs/src/cc/qcdio/QCFdPoll.cc: In member function 'int QCFdPoll::Impl::Close()':
/home.local/trobinson/qfs/src/cc/qcdio/QCFdPoll.cc:311:31: error: 'close' was not declared in this scope

/home.local/trobinson/qfs/src/cc/qcdio/QCThread.cc:199:31: error: '_SC_NPROCESSORS_CONF' was not declared in this scope
/home.local/trobinson/qfs/src/cc/qcdio/QCThread.cc:199:51: error: 'sysconf' was not declared in this scope
/home.local/trobinson/qfs/src/cc/qcdio/QCThread.cc:218:49: error: 'syscall' was not declared in this scope

/home.local/trobinson/qfs/src/cc/tools/qfsdataverify_main.cc: In function 'int main(int, char**)':
/home.local/trobinson/qfs/src/cc/tools/qfsdataverify_main.cc:56:54: error: 'getopt' was not declared in this scope
/home.local/trobinson/qfs/src/cc/tools/qfsdataverify_main.cc:59:30: error: 'optarg' was not declared in this scope

/home.local/trobinson/qfs/src/cc/tools/qfsshell_main.cc: In function 'int KFS::tools::kfsshell_main(int, char**)':
/home.local/trobinson/qfs/src/cc/tools/qfsshell_main.cc:73:51: error: 'getopt' was not declared in this scope
/home.local/trobinson/qfs/src/cc/tools/qfsshell_main.cc:76:30: error: 'optarg' was not declared in this scope
/home.local/trobinson/qfs/src/cc/tools/qfsshell_main.cc:117:16: error: 'optind' was not declared in this scope
```
