### PR TITLE
return the fully qualified path as part of status

### DIFF
--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
@@ -117,7 +117,7 @@ public class QuantcastFileSystem extends FileSystem {
 
   public FileStatus[] listStatus(Path path) throws IOException {
     try {
-      final Path absolute = makeAbsolute(path);
+      final Path absolute = makeAbsolute(path).makeQualified(this);
       final FileStatus fs = qfsImpl.stat(absolute);
       return fs.isDir() ?
         qfsImpl.readdirplus(absolute) :

--- a/src/java/hadoop-qfs/src/test/java/com/quantcast/qfs/hadoop/QFSEmulationImpl.java
+++ b/src/java/hadoop-qfs/src/test/java/com/quantcast/qfs/hadoop/QFSEmulationImpl.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -69,11 +68,11 @@ public class QFSEmulationImpl implements IFSImpl {
   }
 
   public FileStatus[] readdirplus(Path path) throws IOException {
-    return localFS.listStatus(path);
+    return localFS.listStatus(new Path(path.toUri().getPath()));
   }
 
   public FileStatus stat(Path path) throws IOException {
-    return localFS.getFileStatus(path);
+    return localFS.getFileStatus(new Path(path.toUri().getPath()));
   }
 
   public KfsFileAttr fullStat(Path path) throws IOException {


### PR DESCRIPTION
Return fully qualified path as part of listStatus call .. this is needed when QFS is not default filesystem in cluster and cluster has more than one filesystem.

@kstinsonqc 
