### PR TITLE
support building qfs with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos
+RUN  yum install -y \
+     make cmake \
+     boost-devel gcc-c++ openssl-devel \
+     libuuid-devel git \
+     java-1.7.0-openjdk-devel maven
+RUN  mkdir -p /code/qfs
+ADD  . /code/qfs/.
+WORKDIR /code/qfs
+
+CMD ["make"]
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+rm -Rf .bin
+mkdir .bin
+docker build -t qfs-build .
+docker run --rm -v $PWD/.bin:/code/qfs/build/release/bin qfs-build
+


### PR DESCRIPTION
This PR adds Dockerfile and a build script to help quickly building QFS with Docker.
To use it, just clone the repository and call "./build.sh". Docker is required for this build process.

The result binaries from the default `release` configuration will be placed under `~/.bin` after the build is successfully.

Signed-off-by: Chanwit Kaewkasi chanwit@gmail.com
