### PR TITLE
Configurable Disk IO Size

### DIFF
--- a/src/cc/access/qfs_access_jni.cc
+++ b/src/cc/access/qfs_access_jni.cc
@@ -42,6 +42,7 @@ using std::ostringstream;
 
 #include <fcntl.h>
 #include "libclient/KfsClient.h"
+#include "common/kfstypes.h"
 using namespace KFS;
 
 extern "C" {
@@ -117,12 +118,12 @@ extern "C" {
 
     jint Java_com_quantcast_qfs_access_KfsAccess_open(
         JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jstring jmode, jint jnumReplicas,
-        jint jnumStripes, jint jnumRecoveryStripes, jint jstripeSize, jint jstripedType, jint jcreateMode);
+        jint jnumStripes, jint jnumRecoveryStripes, jint jstripeSize, jint jstripedType, jint jcreateMode, jint jtargetDiskIoSize);
 
     jint Java_com_quantcast_qfs_access_KfsAccess_create(
         JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jint jnumReplicas, jboolean jexclusive,
         jint jnumStripes, jint jnumRecoveryStripes, jint jstripeSize, jint jstripedType,
-        jboolean foreceType, jint mode);
+        jboolean foreceType, jint mode, jint jtargetDiskIoSize);
 
     jlong Java_com_quantcast_qfs_access_KfsAccess_setDefaultIoBufferSize(
         JNIEnv *jenv, jclass jcls, jlong jptr, jlong jsize);
@@ -422,7 +423,7 @@ jobjectArray Java_com_quantcast_qfs_access_KfsAccess_readdir(
 jint Java_com_quantcast_qfs_access_KfsAccess_open(
     JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jstring jmode,
     jint jnumReplicas, jint jnumStripes, jint jnumRecoveryStripes,
-    jint jstripeSize, jint jstripedType, jint jcreateMode)
+    jint jstripeSize, jint jstripedType, jint jcreateMode, jint jtargetDiskIoSize)
 {
     if (! jptr) {
         return -EFAULT;
@@ -448,7 +449,7 @@ jint Java_com_quantcast_qfs_access_KfsAccess_open(
         openMode = O_WRONLY | O_APPEND;
 
     return clnt->Open(path.c_str(), openMode, jnumReplicas,
-        jnumStripes, jnumRecoveryStripes, jstripeSize, jstripedType, jcreateMode);
+        jnumStripes, jnumRecoveryStripes, jstripeSize, jstripedType, jcreateMode, kKfsSTierMax, kKfsSTierMax, jtargetDiskIoSize);
 }
 
 jint Java_com_quantcast_qfs_access_KfsInputChannel_close(
@@ -476,7 +477,7 @@ jint Java_com_quantcast_qfs_access_KfsOutputChannel_close(
 jint Java_com_quantcast_qfs_access_KfsAccess_create(
     JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jint jnumReplicas, jboolean jexclusive,
     jint jnumStripes, jint jnumRecoveryStripes, jint jstripeSize, jint jstripedType,
-    jboolean foreceType, jint mode)
+    jboolean foreceType, jint mode, jint jtargetDiskIoSize)
 {
     if (! jptr) {
         return -EFAULT;
@@ -486,7 +487,7 @@ jint Java_com_quantcast_qfs_access_KfsAccess_create(
     string path;
     setStr(path, jenv, jpath);
     return clnt->Create(path.c_str(), jnumReplicas, jexclusive,
-        jnumStripes, jnumRecoveryStripes, jstripeSize, jstripedType, foreceType, (kfsMode_t)mode);
+        jnumStripes, jnumRecoveryStripes, jstripeSize, jstripedType, foreceType, (kfsMode_t)mode, kKfsSTierMax, kKfsSTierMax, jtargetDiskIoSize);
 }
 
 jint Java_com_quantcast_qfs_access_KfsAccess_remove(

--- a/src/cc/libclient/KfsClient.cc
+++ b/src/cc/libclient/KfsClient.cc
@@ -516,16 +516,17 @@ KfsClient::ParseCreateParams(const char* params,
 int
 KfsClient::Create(const char *pathname, int numReplicas, bool exclusive,
     int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-    bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier)
+    bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier,
+    int targetDiskIoSize)
 {
     return mImpl->Create(pathname, numReplicas, exclusive,
         numStripes, numRecoveryStripes, stripeSize, stripedType, forceTypeFlag,
-        mode, minSTier, maxSTier);
+        mode, minSTier, maxSTier, targetDiskIoSize);
 }
 
 
 int
-KfsClient::Create(const char *pathname, bool exclusive, const char *params)
+KfsClient::Create(const char *pathname, bool exclusive, const char *params, int targetDiskIoSize)
 {
     int        numReplicas;
     int        numStripes;
@@ -542,7 +543,7 @@ KfsClient::Create(const char *pathname, bool exclusive, const char *params)
     }
     return mImpl->Create(pathname, numReplicas, exclusive,
         numStripes, numRecoveryStripes, stripeSize, stripedType, true,
-        0666, maxSTier, minSTier);
+        0666, maxSTier, minSTier, targetDiskIoSize);
 }
 
 int
@@ -572,16 +573,16 @@ KfsClient::SetMtime(const char *pathname, const struct timeval &mtime)
 int
 KfsClient::Open(const char *pathname, int openFlags, int numReplicas,
     int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-    kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier)
+    kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier, int targetDiskIoSize)
 {
     return mImpl->Open(pathname, openFlags, numReplicas,
         numStripes, numRecoveryStripes, stripeSize, stripedType, mode,
-        minSTier, maxSTier);
+        minSTier, maxSTier, targetDiskIoSize);
 }
 
 int
 KfsClient::Open(const char *pathname, int openFlags, const char *params,
-    kfsMode_t mode)
+    kfsMode_t mode, int targetDiskIoSize)
 {
     int        numReplicas;
     int        numStripes;
@@ -598,7 +599,7 @@ KfsClient::Open(const char *pathname, int openFlags, const char *params,
     }
     return mImpl->Open(pathname, openFlags, numReplicas,
         numStripes, numRecoveryStripes, stripeSize, stripedType, mode,
-        minSTier, maxSTier);
+        minSTier, maxSTier, targetDiskIoSize);
 }
 
 int
@@ -3199,18 +3200,20 @@ KfsClientImpl::LookupAttr(kfsFileId_t parentFid, const string& filename,
 int
 KfsClientImpl::Create(const char *pathname, int numReplicas, bool exclusive,
     int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-    bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier)
+    bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier,
+    int targetDiskIoSize)
 {
     QCStMutexLocker l(mMutex);
     return CreateSelf(pathname, numReplicas, exclusive,
         numStripes, numRecoveryStripes, stripeSize, stripedType, forceTypeFlag,
-        mode, minSTier, maxSTier);
+        mode, minSTier, maxSTier, targetDiskIoSize);
 }
 
 int
 KfsClientImpl::CreateSelf(const char *pathname, int numReplicas, bool exclusive,
     int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-    bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier)
+    bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier,
+    int targetDiskIoSize)
 {
     if (! pathname || ! *pathname) {
         return -EINVAL;
@@ -3300,6 +3303,8 @@ KfsClientImpl::CreateSelf(const char *pathname, int numReplicas, bool exclusive,
     fa.fileSize    = 0; // presently CreateOp always deletes file if exists.
     fa.minSTier    = op.minSTier;
     fa.maxSTier    = op.maxSTier;
+    entry.mTargetDiskIoSize = (targetDiskIoSize + CHECKSUM_BLOCKSIZE - 1) /
+    							CHECKSUM_BLOCKSIZE * CHECKSUM_BLOCKSIZE;
     if (op.metaStriperType != KFS_STRIPED_FILE_TYPE_NONE) {
         fa.numStripes         = (int16_t)numStripes;
         fa.numRecoveryStripes = (int16_t)numRecoveryStripes;
@@ -3328,6 +3333,7 @@ KfsClientImpl::CreateSelf(const char *pathname, int numReplicas, bool exclusive,
         " instance: " << entry.instance <<
         " mode: "     << entry.openMode <<
         " striper: "  << fa.striperType <<
+        " targetDiskIoSize: " << entry.mTargetDiskIoSize <<
     KFS_LOG_EOM;
 
     return fte;
@@ -3773,13 +3779,13 @@ KfsClientImpl::ReadDirectory(int fd, char* buf, size_t numBytes)
 int
 KfsClientImpl::Open(const char *pathname, int openMode, int numReplicas,
     int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-    kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier)
+    kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier, int targetDiskIoSize)
 {
     QCStMutexLocker l(mMutex);
     const bool kCacheAttributesFlag = false;
     return OpenSelf(pathname, openMode, numReplicas,
         numStripes, numRecoveryStripes, stripeSize, stripedType,
-        minSTier, maxSTier, kCacheAttributesFlag, mode);
+        minSTier, maxSTier, kCacheAttributesFlag, mode, 0, targetDiskIoSize);
 }
 
 int
@@ -3806,7 +3812,7 @@ int
 KfsClientImpl::OpenSelf(const char *pathname, int openMode, int numReplicas,
     int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
     kfsSTier_t minSTier, kfsSTier_t maxSTier,
-    bool cacheAttributesFlag, kfsMode_t mode, string* path)
+    bool cacheAttributesFlag, kfsMode_t mode, string* path, int targetDiskIoSize)
 {
     if ((openMode & O_TRUNC) != 0 &&
             (openMode & (O_RDWR | O_WRONLY | O_APPEND)) == 0) {
@@ -3855,7 +3861,7 @@ KfsClientImpl::OpenSelf(const char *pathname, int openMode, int numReplicas,
                 const int fte = CreateSelf(pathname, numReplicas,
                     openMode & O_EXCL,
                     numStripes, numRecoveryStripes, stripeSize, stripedType,
-                    false, mode, minSTier, maxSTier);
+                    false, mode, minSTier, maxSTier, targetDiskIoSize);
                 if (fte >= 0 && (openMode & O_APPEND) != 0) {
                     FileTableEntry& entry = *mFileTable[fte];
                     assert(! entry.fattr.isDirectory);
@@ -3918,6 +3924,7 @@ KfsClientImpl::OpenSelf(const char *pathname, int openMode, int numReplicas,
         entry.openMode = 0;
     }
     entry.fattr = fattr;
+    entry.mTargetDiskIoSize = targetDiskIoSize;
     const bool truncateFlag =
         ! cacheAttributesFlag && (openMode & O_TRUNC) != 0;
     if (truncateFlag) {
@@ -4697,7 +4704,8 @@ KfsClientImpl::SetIoBufferSize(FileTableEntry& entry, size_t size, bool optimalF
         const int stripes =
             attr.numStripes + max(0, int(attr.numRecoveryStripes));
         const int stride  = attr.stripeSize * stripes;
-        bufSize = (max(optimalFlag ? mTargetDiskIoSize * stripes : 0, bufSize) +
+        const int theTargetDiskIoSize = (entry.mTargetDiskIoSize > 0 ? entry.mTargetDiskIoSize : mTargetDiskIoSize);
+        bufSize = (max(optimalFlag ? theTargetDiskIoSize * stripes : 0, bufSize) +
             stride - 1) / stride * stride;
     }
     entry.ioBufferSize = max(0, bufSize);

--- a/src/cc/libclient/KfsClient.h
+++ b/src/cc/libclient/KfsClient.h
@@ -302,6 +302,10 @@ public:
     /// @param[in] numReplicas the desired degree of replication for
     /// the file.
     /// @param[in] exclusive  create will fail if the exists (O_EXCL flag)
+    /// @param[in] targetDiskIoSize maximum number of bytes written/read
+    /// between client and chunk-server each time. If this parameter is not provided,
+    /// the corresponding value (defaults to 1MB) is set by the environment variable
+    /// QFS_CLIENT_CONFIG='client.targetDiskIoSize'.
     /// @retval on success, fd corresponding to the created file;
     /// -errno on failure.
     ///
@@ -309,17 +313,22 @@ public:
         int numStripes = 0, int numRecoveryStripes = 0, int stripeSize = 0,
         int stripedType = KFS_STRIPED_FILE_TYPE_NONE, bool forceTypeFlag = true,
         kfsMode_t mode = 0666,
-        kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax);
+        kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax,
+        int targetDiskIoSize = 0);
 
     ///
     /// Create a file which is specified by a complete path.
     /// @param[in] pathname that has to be created
     /// @param[in] exclusive  create will fail if the exists (O_EXCL flag)
     /// @param[in] params in ParseCreateParams() format
+    /// @param[in] targetDiskIoSize maximum number of bytes written/read
+    /// between client and chunk-server each time. If this parameter is not provided,
+    /// the corresponding value (defaults to 1MB) is set by the environment variable
+    /// QFS_CLIENT_CONFIG='client.targetDiskIoSize'.
     /// @retval on success, fd corresponding to the created file;
     /// -errno on failure.
     ///
-    int Create(const char *pathname, bool exclusive, const char* params);
+    int Create(const char *pathname, bool exclusive, const char* params, int targetDiskIoSize = 0);
 
     ///
     /// Remove a file which is specified by a complete path.
@@ -355,23 +364,32 @@ public:
     /// O_CREAT, O_CREAT|O_EXCL, O_RDWR, O_RDONLY, O_WRONLY, O_TRUNC, O_APPEND
     /// @param[in] numReplicas if O_CREAT is specified, then this the
     /// desired degree of replication for the file
+    /// @param[in] targetDiskIoSize maximum number of bytes written/read
+    /// between client and chunk-server each time. If this parameter is not provided,
+    /// the corresponding value (defaults to 1MB) is set by the environment variable
+    /// QFS_CLIENT_CONFIG='client.targetDiskIoSize'.
     /// @retval fd corresponding to the opened file; -errno on failure
     ///
     int Open(const char *pathname, int openFlags, int numReplicas = 3,
         int numStripes = 0, int numRecoveryStripes = 0, int stripeSize = 0,
         int stripedType = KFS_STRIPED_FILE_TYPE_NONE,
         kfsMode_t mode = 0666,
-        kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax);
+        kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax,
+        int targetDiskIoSize = 0);
 
     ///
     /// Create a file which is specified by a complete path.
     /// @param[in] pathname that has to be created
     /// @param[in] params in ParseCreateParams() format
+    /// @param[in] targetDiskIoSize maximum number of bytes written/read
+    /// between client and chunk-server each time. If this parameter is not provided,
+    /// the corresponding value (defaults to 1MB) is set by the environment variable
+    /// QFS_CLIENT_CONFIG='client.targetDiskIoSize'.
     /// @retval on success, fd corresponding to the created file;
     /// -errno on failure.
     ///
     int Open(const char *pathname, int openFlags, const char* params,
-        kfsMode_t mode = 0666);
+        kfsMode_t mode = 0666, int targetDiskIoSize = 0);
 
     ///
     /// Close a file

--- a/src/cc/libclient/KfsClientInt.h
+++ b/src/cc/libclient/KfsClientInt.h
@@ -210,6 +210,7 @@ struct FileTableEntry {
     int                  ioBufferSize;
     ReadBuffer           buffer;
     ReadRequest*         mReadQueue[1];
+    int                  mTargetDiskIoSize;
 
     FileTableEntry(kfsFileId_t p, const string& n, unsigned int instance):
         parentFid(p),
@@ -228,7 +229,8 @@ struct FileTableEntry {
         pending(0),
         dirEntries(0),
         ioBufferSize(0),
-        buffer()
+        buffer(),
+        mTargetDiskIoSize(0)
         { mReadQueue[0] = 0; }
     ~FileTableEntry()
     {
@@ -382,6 +384,8 @@ public:
     /// @param[in] numReplicas the desired degree of replication for
     /// the file.
     /// @param[in] exclusive  create will fail if the exists (O_EXCL flag)
+    /// @param[in] targetDiskIoSize maximum number of bytes written/read
+    /// between client and chunk-server each time
     /// @retval on success, fd corresponding to the created file;
     /// -errno on failure.
     ///
@@ -389,7 +393,8 @@ public:
         int numStripes = 0, int numRecoveryStripes = 0, int stripeSize = 0,
         int stripedType = KFS_STRIPED_FILE_TYPE_NONE, bool forceTypeFlag = true,
         kfsMode_t mode = kKfsModeUndef,
-        kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax);
+        kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax,
+        int targetDiskIoSize = 0);
 
     ///
     /// Remove a file which is specified by a complete path.
@@ -426,11 +431,13 @@ public:
     /// O_CREAT, O_CREAT|O_EXCL, O_RDWR, O_RDONLY, O_WRONLY, O_TRUNC, O_APPEND
     /// @param[in] numReplicas if O_CREAT is specified, then this the
     /// desired degree of replication for the file
+    /// @param[in] targetDiskIoSize maximum number of bytes written/read
+    /// between client and chunk-server each time
     /// @retval fd corresponding to the opened file; -errno on failure
     ///
     int Open(const char *pathname, int openFlags, int numReplicas,
         int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-        kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier);
+        kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier, int targetDiskIoSize);
 
     ///
     /// Close a file
@@ -856,14 +863,15 @@ private:
         int stripedType = KFS_STRIPED_FILE_TYPE_NONE,
         kfsSTier_t minSTier = kKfsSTierMax, kfsSTier_t maxSTier = kKfsSTierMax,
         bool cacheAttributesFlag = false,
-        kfsMode_t mode = kKfsModeUndef, string* path = 0);
+        kfsMode_t mode = kKfsModeUndef, string* path = 0, int targetDiskIoSize = 0);
     int CacheAttributes(const char* pathname);
     int GetDataLocationSelf(int fd, chunkOff_t start, chunkOff_t len,
         vector<vector<string> >& locations, chunkOff_t* outBlkSize);
     int TruncateSelf(int fd, chunkOff_t offset);
     int CreateSelf(const char *pathname, int numReplicas, bool exclusive,
         int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-        bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier);
+        bool forceTypeFlag, kfsMode_t mode, kfsSTier_t minSTier, kfsSTier_t maxSTier,
+        int targetDiskIoSize);
     ssize_t SetReadAheadSize(FileTableEntry& inEntry, size_t inSize, bool optimalFlag = false);
     ssize_t SetIoBufferSize(FileTableEntry& entry, size_t size, bool optimalFlag = false);
     ssize_t SetOptimalIoBufferSize(FileTableEntry& entry, size_t size) {

--- a/src/cc/libclient/KfsProtocolWorker.h
+++ b/src/cc/libclient/KfsProtocolWorker.h
@@ -130,7 +130,8 @@ public:
             void*         inBufferPtr    = 0,
             int           inSize         = 0,
             int           inMaxPending   = -1,
-            int64_t       inOffset       = -1);
+            int64_t       inOffset       = -1,
+            int           inTargetDiskIoSize = 0);
         void Reset(
             RequestType   inOpType       = kRequestTypeUnknown,
             FileInstance  inFileInstance = 0,
@@ -139,7 +140,8 @@ public:
             void*         inBufferPtr    = 0,
             int           inSize         = 0,
             int           inMaxPending   = -1,
-            int64_t       inOffset       = -1);
+            int64_t       inOffset       = -1,
+            int           inTargetDiskIoSize = 0);
         virtual void Done(
             int64_t inStatus) = 0;
         int64_t GetOffset() const
@@ -168,6 +170,7 @@ public:
         int64_t       mStatus;
         int64_t       mMaxPendingOrEndPos;
         int64_t       mOffset;
+        int           mTargetDiskIoSize;
     private:
         Request* mPrevPtr[1];
         Request* mNextPtr[1];
@@ -271,7 +274,8 @@ public:
         void*                  inBufferPtr  = 0,
         int                    inSize       = 0,
         int                    inMaxPending = -1,
-        int64_t                inOffset     = -1);
+        int64_t                inOffset     = -1,
+        int                    inTargetDiskIoSize = 0);
     void ExecuteMeta(
         KfsOp& inOp);
     Properties GetStats();

--- a/src/cc/libclient/KfsRead.cc
+++ b/src/cc/libclient/KfsRead.cc
@@ -417,7 +417,8 @@ private:
             inBufPtr,
             inSize,
             0, // inMaxPending,
-            inOffset
+            inOffset,
+            inEntry.mTargetDiskIoSize
         );
         if (GetSize() <= 0) {
             return 0;
@@ -605,6 +606,7 @@ KfsClientImpl::Read(
     int64_t       theLen           = min(theEof - thePos, (int64_t)inSize);
     const int     theSize          = (int)theLen;
     const bool    theSkipHolesFlag = theEntry.skipHoles;
+    const int	  theTargetDiskIoSize = theEntry.mTargetDiskIoSize;
     if (theLen <= 0) {
         return 0;
     }
@@ -769,7 +771,8 @@ KfsClientImpl::Read(
             inBufPtr + theRet,
             theRdSize,
             0,
-            thePos
+            thePos,
+            theTargetDiskIoSize
         );
         if (theSkipHolesFlag && theStatus == -ENOENT) {
             theStatus = 0;
@@ -846,8 +849,9 @@ KfsClientImpl::SetReadAheadSize(
             theAttr.numStripes > 0 &&
             theAttr.stripeSize < theSize) {
         const int theStride = theAttr.stripeSize * theAttr.numStripes;
+        const int theTargetDiskIoSize = (inEntry.mTargetDiskIoSize > 0 ? inEntry.mTargetDiskIoSize : mTargetDiskIoSize);
         theSize = (max(inOptimalFlag ?
-                mTargetDiskIoSize * theAttr.numStripes : 0, theSize) +
+                theTargetDiskIoSize * theAttr.numStripes : 0, theSize) +
             theStride - 1) / theStride * theStride;
     }
     inEntry.buffer.SetBufSize(theSize);

--- a/src/cc/libclient/KfsWrite.cc
+++ b/src/cc/libclient/KfsWrite.cc
@@ -143,6 +143,7 @@ KfsClientImpl::Write(int fd, const char *buf, size_t numBytes,
     const string                          pathName     = entry.pathname;
     const int                             bufsz        = entry.ioBufferSize;
     const int                             prevPending  = entry.pending;
+    const int                             targetDiskIoSize = entry.mTargetDiskIoSize;
     const bool                            throttle     =
         ! asyncFlag && bufsz > 0 && bufsz <= entry.pending;
     if ((throttle || bufsz <= 0) && ! asyncFlag) {
@@ -183,7 +184,8 @@ KfsClientImpl::Write(int fd, const char *buf, size_t numBytes,
         const_cast<char*>(buf),
         numBytes,
         (throttle || (! appendFlag && bufsz >= 0)) ? bufsz : -1,
-        offset
+        offset,
+        targetDiskIoSize
     );
     if (status < 0) {
         return (ssize_t)status;

--- a/src/java/hadoop-qfs-2/src/main/java/com/quantcast/qfs/hadoop/Qfs.java
+++ b/src/java/hadoop-qfs-2/src/main/java/com/quantcast/qfs/hadoop/Qfs.java
@@ -103,6 +103,22 @@ public class Qfs extends AbstractFileSystem {
     ChecksumOpt         checksumOpt,
     boolean             createParent)
       throws IOException {
+    return createInternal(path, createFlag, absolutePermission, bufferSize, 
+            replication, blockSize, progress, checksumOpt, createParent, 0);
+  }
+  
+  public FSDataOutputStream createInternal(
+    Path                path,
+    EnumSet<CreateFlag> createFlag,
+    FsPermission        absolutePermission,
+    int                 bufferSize,
+    short               replication,
+    long                blockSize,
+    Progressable        progress,
+    ChecksumOpt         checksumOpt,
+    boolean             createParent,
+    int                 targetDiskIoSize)
+      throws IOException {
     CreateFlag.validate(createFlag);
     if (createParent) {
       mkdir(path.getParent(), absolutePermission, createParent);
@@ -113,6 +129,7 @@ public class Qfs extends AbstractFileSystem {
       bufferSize,
       createFlag.contains(CreateFlag.OVERWRITE),
       absolutePermission.toShort(),
+      targetDiskIoSize,
       createFlag.contains(CreateFlag.APPEND)
     );
   }
@@ -196,9 +213,14 @@ public class Qfs extends AbstractFileSystem {
   @Override
   public FSDataInputStream open(Path path, int bufferSize)
       throws IOException, UnresolvedLinkException {
-    return qfs.open(path, bufferSize);
+    return open(path, bufferSize, 0);
   }
 
+  public FSDataInputStream open(Path path, int bufferSize, int targetDiskIoSize)
+      throws IOException, UnresolvedLinkException {
+    return qfs.open(path, bufferSize, targetDiskIoSize);
+  }
+  
   @Override
   public void renameInternal(Path src, Path dst)
       throws IOException, UnresolvedLinkException {

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/IFSImpl.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/IFSImpl.java
@@ -62,13 +62,13 @@ interface IFSImpl {
 
   public long getModificationTime(String path) throws IOException;
   public FSDataOutputStream create(String path, short replication,
-           int bufferSize, boolean overwrite, int mode) throws IOException;
+           int bufferSize, boolean overwrite, int mode, int targetDiskIoSize) throws IOException;
   public FSDataOutputStream create(String path, short replication,
             int bufferSize, boolean overwrite, int mode,
-            boolean append) throws IOException;
+            int targetDiskIoSize, boolean append) throws IOException;
   public FSDataOutputStream append(String path, short replication,
            int bufferSize) throws IOException;
-  public FSDataInputStream open(String path, int bufferSize)
+  public FSDataInputStream open(String path, int bufferSize, int targetDiskIoSize)
            throws IOException;
   public void setPermission(String path, int mode) throws IOException;
   public void setOwner(String path, String username, String groupname)

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSImpl.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSImpl.java
@@ -235,22 +235,22 @@ class QFSImpl implements IFSImpl {
 
   public FSDataOutputStream create(String path, short replication,
                                    int bufferSize, boolean overwrite,
-                                   int mode) throws IOException {
+                                   int mode, int targetDiskIoSize) throws IOException {
     final boolean append = false;
-    return create(path, replication, bufferSize, overwrite, mode, append);
+    return create(path, replication, bufferSize, overwrite, mode, targetDiskIoSize, append);
   }
 
   public FSDataOutputStream create(String path, short replication,
         int bufferSize, boolean overwrite, int mode,
-        boolean append) throws IOException {
+        int targetDiskIoSize, boolean append) throws IOException {
     return new FSDataOutputStream(createQFSOutputStream(
-      kfsAccess, path, replication, overwrite, append, mode), statistics);
+      kfsAccess, path, replication, overwrite, append, mode, targetDiskIoSize), statistics);
   }
 
-  public FSDataInputStream open(String path, int bufferSize)
+  public FSDataInputStream open(String path, int bufferSize, int targetDiskIoSize)
     throws IOException {
       return new FSDataInputStream(createQFSInputStream(kfsAccess, path,
-                                                      statistics));
+                                                      targetDiskIoSize, statistics));
   }
 
   public FSDataOutputStream append(String path, short replication,
@@ -258,8 +258,9 @@ class QFSImpl implements IFSImpl {
     final boolean append    = true;
     final boolean overwrite = false;
     final int     mode      = 0666;
+    final int targetDiskIoSize = 0;
     return new FSDataOutputStream(createQFSOutputStream(
-      kfsAccess, path, replication, overwrite, append, mode), statistics);
+      kfsAccess, path, replication, overwrite, append, mode, targetDiskIoSize), statistics);
   }
 
   public void setPermission(String path, int mode) throws IOException {
@@ -279,13 +280,13 @@ class QFSImpl implements IFSImpl {
 
   protected QFSOutputStream createQFSOutputStream(KfsAccess kfsAccess, String path,
                                                   short replication, boolean overwrite,
-                                                  boolean append, int mode) throws IOException {
-    return new QFSOutputStream(kfsAccess, path, replication, overwrite, append, mode);
+                                                  boolean append, int mode, int targetDiskIoSize) throws IOException {
+    return new QFSOutputStream(kfsAccess, path, replication, overwrite, append, mode, targetDiskIoSize);
   }
 
   protected QFSInputStream createQFSInputStream(KfsAccess kfsAccess, String path,
-                                                FileSystem.Statistics stats) throws IOException {
-    return new QFSInputStream(kfsAccess, path, stats);
+                                                int targetDiskIoSize, FileSystem.Statistics stats) throws IOException {
+    return new QFSInputStream(kfsAccess, path, targetDiskIoSize, stats);
   }
 
   public CloseableIterator<FileStatus> getFileStatusIterator(FileSystem fs, Path path)

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSInputStream.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSInputStream.java
@@ -34,9 +34,9 @@ class QFSInputStream extends FSInputStream {
   private final long fsize;
 
   public QFSInputStream(KfsAccess kfsAccess, String path,
-                        FileSystem.Statistics stats) throws IOException {
+                        int targetDiskIoSize, FileSystem.Statistics stats) throws IOException {
     this.statistics = stats;
-    this.kfsChannel = kfsAccess.kfs_open_ex(path, -1, -1);
+    this.kfsChannel = kfsAccess.kfs_open_ex(path, -1, -1, targetDiskIoSize);
     if (kfsChannel == null) {
       throw new IOException("QFS internal error -- null channel");
     }

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSOutputStream.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSOutputStream.java
@@ -36,7 +36,7 @@ class QFSOutputStream extends OutputStream {
   private final KfsOutputChannel kfsChannel;
 
   public QFSOutputStream(KfsAccess kfsAccess, String path, short replication,
-    boolean overwrite, boolean append, int mode) throws IOException {
+    boolean overwrite, boolean append, int mode, int targetDiskIoSize) throws IOException {
     if (append) {
       this.kfsChannel = kfsAccess.kfs_append_ex(path, (int)replication, mode);
     } else {
@@ -44,7 +44,7 @@ class QFSOutputStream extends OutputStream {
       final long    readAheadSize = -1;
       final boolean exclusive     = ! overwrite;
       this.kfsChannel = kfsAccess.kfs_create_ex(
-        path, replication, exclusive, bufferSize, readAheadSize, mode);
+        path, replication, exclusive, bufferSize, readAheadSize, mode, targetDiskIoSize);
     }
     if (kfsChannel == null) {
       throw new IOException("QFS internal error -- null channel");

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
@@ -169,28 +169,46 @@ public class QuantcastFileSystem extends FileSystem {
   public FSDataOutputStream create(Path file, FsPermission permission,
                                    boolean overwrite, int bufferSize,
                                    short replication, long blockSize,
-                                   Progressable progress)
-    throws IOException {
+                                   Progressable progress) throws IOException {
+      return create(file, permission, overwrite, bufferSize, replication,
+              blockSize, 0, progress);
+  }
+  
+  public FSDataOutputStream create(Path file, FsPermission permission,
+                                   boolean overwrite, int bufferSize,
+                                   short replication, long blockSize,
+                                   int targetDiskIoSize, Progressable progress) throws IOException {
     Path parent = file.getParent();
     if (parent != null && !mkdirs(parent)) {
       throw new IOException("Mkdirs failed to create " + parent);
     }
     return qfsImpl.create(makeAbsolute(file).toUri().getPath(),
-      replication, bufferSize, overwrite, permission.toShort());
+      replication, bufferSize, overwrite, permission.toShort(), targetDiskIoSize);
   }
 
+  public FSDataOutputStream createNonRecursive(Path file, FsPermission permission,
+                                               boolean overwrite, int bufferSize,
+                                               short replication, long blockSize,
+                                               Progressable progress) throws IOException {
+      return createNonRecursive(file, permission, overwrite, bufferSize, replication, 
+              blockSize, 0, progress);
+  }
+  
   public FSDataOutputStream createNonRecursive(Path file,
                                    FsPermission permission,
                                    boolean overwrite, int bufferSize,
                                    short replication, long blockSize,
-                                   Progressable progress)
-    throws IOException {
-    return qfsImpl.create(makeAbsolute(file).toUri().getPath(),
-      replication, bufferSize, overwrite, permission.toShort());
+                                   int targetDiskIoSize, Progressable progress) throws IOException {
+      return qfsImpl.create(makeAbsolute(file).toUri().getPath(), 
+              replication, bufferSize, overwrite, permission.toShort(), targetDiskIoSize);
   }
 
   public FSDataInputStream open(Path path, int bufferSize) throws IOException {
-    return qfsImpl.open(makeAbsolute(path).toUri().getPath(), bufferSize);
+      return open(path, bufferSize, 0);
+  }
+  
+  public FSDataInputStream open(Path path, int bufferSize, int targetDiskIoSize) throws IOException {
+      return qfsImpl.open(makeAbsolute(path).toUri().getPath(), bufferSize, targetDiskIoSize);
   }
 
   public boolean rename(Path src, Path dst) throws IOException {


### PR DESCRIPTION
Support for configurable disk IO size for each file. Users can set a specific disk IO size for a file by passing an additional parameter to KfsClient::Create() and KfsClient::Open() functions. The assigned value sets how many bytes the client sends/reads to/from a chunk server at each time. This effectively changes the size of IO operations between a chunk server and the underlying storage device. Also, write-behind threshold and read-ahead buffer size is changed with respect to the given disk IO size.