### PR TITLE
Web ui: Fix when chunk advertised hostname is a domain

### DIFF
--- a/webui/qfsstatus.py
+++ b/webui/qfsstatus.py
@@ -691,6 +691,7 @@ class UpServer:
 
             if hasattr(self, 's'):
                 setattr(self, 'host', self.s)
+                setattr(self, 'ip', socket.gethostbyname(self.s))
                 delattr(self, 's')
 
             if hasattr(self, 'p'):
@@ -794,7 +795,7 @@ class UpServer:
 
     def __cmp__(self, other):
         """ Order by IP"""
-        return cmp(socket.inet_aton(self.host), socket.inet_aton(other.host))
+        return cmp(socket.inet_aton(self.ip), socket.inet_aton(other.ip))
 
     def setRetiring(self, status):
         self.retiring = 1


### PR DESCRIPTION
Related to #69 when I set `chunkServer.hostname` to a dns name, the metaserver and chunkserver communication works, but the webui is broken (returning 504 errors).

The problem is [here](https://github.com/quantcast/qfs/blob/master/webui/qfsstatus.py#L795). It expects two IP addresses but it has two dns names. I'm doing a dns lookup now when instantiating the class.

The error:

```
  File "qfsstatus.py", line 1177, in ping
    status.upServers.sort()
  File "qfsstatus.py", line 799, in __cmp__
    return cmp(socket.inet_aton(self.host), socket.inet_aton(other.host))
error: illegal IP address string passed to inet_aton
```