### PR TITLE
qcdio: remove definition of _GNU_SOURCE from the codebase

### DIFF
--- a/src/cc/qcdio/CMakeLists.txt
+++ b/src/cc/qcdio/CMakeLists.txt
@@ -32,7 +32,7 @@ QCUtils.cc
 )
 
 string(TOUPPER QC_OS_NAME_${CMAKE_SYSTEM_NAME} QC_OS_NAME)
-add_definitions (-D_GNU_SOURCE -D${QC_OS_NAME} -DQC_USE_BOOST)
+add_definitions (-D${QC_OS_NAME} -DQC_USE_BOOST)
 
 #
 # Build a static and a dynamically linked libraries.  Both libraries

--- a/src/cc/qcdio/QCUtils.cc
+++ b/src/cc/qcdio/QCUtils.cc
@@ -75,8 +75,8 @@ DoSysErrorMsg(
             StrAppend(" ", theMsgPtr, theMaxLen);
         }
 #if defined(__EXTENSIONS__) || defined(QC_OS_NAME_DARWIN) || defined(QC_OS_NAME_FREEBSD) || \
-    (! defined(_GNU_SOURCE) && (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600 || \
-                                defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L))
+    (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600 || \
+                defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L)
         int theErr = strerror_r(inSysError, theMsgPtr, theMaxLen);
         if (theErr != 0) {
             theMsgPtr[0] = 0;

--- a/src/cc/qcdio/iovperf.c
+++ b/src/cc/qcdio/iovperf.c
@@ -37,9 +37,6 @@
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
 #endif
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 
 #include <unistd.h>
 #include <sys/types.h>

--- a/src/test-scripts/rwtest.c
+++ b/src/test-scripts/rwtest.c
@@ -32,9 +32,6 @@
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
 #endif
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 
 #include <unistd.h>
 #include <sys/types.h>


### PR DESCRIPTION
It makes code possibly depend on non-portable APIs and the code builds without it.