### PR TITLE
appveyor: remove caching the build directory

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,6 @@ environment:
 
 cache:
     - '%CYG_CACHE%'
-    - '%APPVEYOR_BUILD_FOLDER%\build' # appveyor is super slow -- cache the build so we only build diffs
 
 init:
     - git config --global core.autocrlf input


### PR DESCRIPTION
we can only cache up to 500 mb on appveyor and our build directory is near 2 gb