### PR TITLE
use a more robust wget command to download gtest dependency

### DIFF
--- a/cmake/Modules/Findgtest.cmake
+++ b/cmake/Modules/Findgtest.cmake
@@ -6,8 +6,8 @@ find_package(Threads REQUIRED)
 include(ExternalProject)
 ExternalProject_Add(
     gtest
-    # we provide our own command here, since default curl binary used by Cmake might not support SSL.
-    DOWNLOAD_COMMAND /bin/sh -c "wget https://github.com/google/googletest/archive/release-1.7.0.zip && unzip release-1.7.0.zip &&  mv googletest-release-1.7.0/* gtest/ && rm -rf googletest-release-1.7.0"
+    # we provide our own command here, since default curl binary used by Cmake might not support SSL)
+    DOWNLOAD_COMMAND /bin/sh -c "wget -O release-1.7.0.zip https://github.com/google/googletest/archive/release-1.7.0.zip && unzip release-1.7.0.zip &&  mv googletest-release-1.7.0/* gtest/ && rm -rf googletest-release-1.7.0"
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
     INSTALL_COMMAND "" # Disable install step
 )


### PR DESCRIPTION
In some machines, file extension (.zip) of downloaded gtest file gets stripped away which causes the proceeding commands to fail. This change makes sure that filename of gtest package stays the same after it's downloaded.