### PR TITLE
rat: check specific files for license information

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -1,0 +1,14 @@
+# Individual files
+.*.cmake
+.gitignore
+.appveyor.yml
+.ratignore
+.travis.yml
+README.md
+tags
+
+# Directories
+ext
+wiki
+travis
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,3 +184,9 @@ add_subdirectory(${KFS_DIR_PREFIX}/contrib/plugins contrib/plugins)
 if(FUSE_FOUND)
     add_subdirectory(${KFS_DIR_PREFIX}/src/cc/fuse src/cc/fuse)
 endif()
+
+add_custom_target (
+    rat ALL COMMAND ../../scripts/rat.sh ../..
+    COMMENT "Running license release audit tool (rat)"
+    VERBATIM
+)

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,13 @@ MAKE_OPTIONS ?=
 .PHONY: all
 all: build
 
-.PHONY: build
-build:
+.PHONY: dir
+dir:
 	export BUILD_TYPE=${BUILD_TYPE}
 	mkdir -p build/${BUILD_TYPE}
+
+.PHONY: build
+build: dir
 	cd build/${BUILD_TYPE} && cmake ${CMAKE_OPTIONS} ../..
 	cd build/${BUILD_TYPE} && $(MAKE) ${MAKE_OPTIONS} install
 
@@ -89,6 +92,11 @@ test: build
 .PHONY: gtest
 gtest: build
 	build/${BUILD_TYPE}/src/cc/tests/test.t
+
+.PHONY: rat
+rat: dir
+	cd build/${BUILD_TYPE} && cmake ${CMAKE_OPTIONS} ../..
+	cd build/${BUILD_TYPE} && $(MAKE) ${MAKE_OPTIONS} rat
 
 .PHONY: clean
 clean:

--- a/scripts/rat.sh
+++ b/scripts/rat.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 source_dir"
+    exit 1
+fi
+
+SRC=$1
+DIR=apache-rat-0.11
+TAR=$DIR-bin.tar.gz
+URL=http://mirror.cogentco.com/pub/apache/creadur/$DIR/$TAR
+
+if [ ! -e $TAR ]; then
+    curl --silent $URL > $TAR
+fi
+
+tar -xf $TAR
+java -jar $DIR/$DIR.jar --dir $SRC -E $SRC/.ratignore | egrep '^==[^=]' | sed -e 's,==../../,,g'


### PR DESCRIPTION
This change adds a new make target, rat, which allows users to check files
within the qfs source tree for missing license information. The file .ratignore
is used as a list of regular expressions for files which should be ignored.