### PR TITLE
add API support to pass create parameters for new files

### DIFF
--- a/src/cc/access/qfs_access_jni.cc
+++ b/src/cc/access/qfs_access_jni.cc
@@ -122,7 +122,11 @@ extern "C" {
     jint Java_com_quantcast_qfs_access_KfsAccess_create(
         JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jint jnumReplicas, jboolean jexclusive,
         jint jnumStripes, jint jnumRecoveryStripes, jint jstripeSize, jint jstripedType,
-        jboolean foreceType, jint mode);
+        jboolean foreceType, jint mode, jint jminSTier, jint jmaxSTier);
+
+    jint Java_com_quantcast_qfs_access_KfsAccess_create2(
+        JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jboolean jexclusive,
+        jstring jcreateParams);
 
     jlong Java_com_quantcast_qfs_access_KfsAccess_setDefaultIoBufferSize(
         JNIEnv *jenv, jclass jcls, jlong jptr, jlong jsize);
@@ -476,7 +480,7 @@ jint Java_com_quantcast_qfs_access_KfsOutputChannel_close(
 jint Java_com_quantcast_qfs_access_KfsAccess_create(
     JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jint jnumReplicas, jboolean jexclusive,
     jint jnumStripes, jint jnumRecoveryStripes, jint jstripeSize, jint jstripedType,
-    jboolean foreceType, jint mode)
+    jboolean foreceType, jint mode, jint minSTier, jint maxSTier)
 {
     if (! jptr) {
         return -EFAULT;
@@ -486,7 +490,23 @@ jint Java_com_quantcast_qfs_access_KfsAccess_create(
     string path;
     setStr(path, jenv, jpath);
     return clnt->Create(path.c_str(), jnumReplicas, jexclusive,
-        jnumStripes, jnumRecoveryStripes, jstripeSize, jstripedType, foreceType, (kfsMode_t)mode);
+        jnumStripes, jnumRecoveryStripes, jstripeSize, jstripedType, foreceType,
+        (kfsMode_t)mode, (kfsSTier_t)minSTier, (kfsSTier_t)maxSTier);
+}
+
+jint Java_com_quantcast_qfs_access_KfsAccess_create2(
+    JNIEnv *jenv, jclass jcls, jlong jptr, jstring jpath, jboolean jexclusive,
+    jstring jcreateParams)
+{
+    if (! jptr) {
+        return -EFAULT;
+    }
+    KfsClient* const clnt = (KfsClient*)jptr;
+
+    string path, createParams;
+    setStr(path, jenv, jpath);
+    setStr(createParams, jenv, jcreateParams);
+    return clnt->Create(path.c_str(), (bool) jexclusive, createParams.c_str());
 }
 
 jint Java_com_quantcast_qfs_access_KfsAccess_remove(

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/IFSImpl.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/IFSImpl.java
@@ -66,6 +66,8 @@ interface IFSImpl {
   public FSDataOutputStream create(String path, short replication,
             int bufferSize, boolean overwrite, int mode,
             boolean append) throws IOException;
+  public FSDataOutputStream create(String path, boolean overwrite,
+          String createParams) throws IOException;
   public FSDataOutputStream append(String path, short replication,
            int bufferSize) throws IOException;
   public FSDataInputStream open(String path, int bufferSize)

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSOutputStream.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSOutputStream.java
@@ -51,6 +51,15 @@ class QFSOutputStream extends OutputStream {
     }
   }
 
+  public QFSOutputStream(KfsAccess kfsAccess, String path, boolean overwrite,
+          String createParams) throws IOException {
+      final boolean exclusive     = ! overwrite;
+      this.kfsChannel = kfsAccess.kfs_create_ex(path, exclusive, createParams);    
+      if (kfsChannel == null) {
+        throw new IOException("QFS internal error -- null channel");
+      }
+  }
+
   public long getPos() throws IOException {
     return kfsChannel.tell();
   }

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
@@ -177,6 +177,16 @@ public class QuantcastFileSystem extends FileSystem {
       replication, bufferSize, overwrite, permission.toShort());
   }
 
+  public FSDataOutputStream create(Path file, boolean overwrite,
+          String createParams) throws IOException {
+    Path parent = file.getParent();
+    if (parent != null && !mkdirs(parent)) {
+        throw new IOException("Mkdirs failed to create " + parent);
+    }
+    return qfsImpl.create(makeAbsolute(file).toUri().getPath(),
+            overwrite, createParams);
+  }
+
   public FSDataOutputStream createNonRecursive(Path file,
                                    FsPermission permission,
                                    boolean overwrite, int bufferSize,

--- a/src/java/hadoop-qfs/src/test/java/com/quantcast/qfs/hadoop/QFSEmulationImpl.java
+++ b/src/java/hadoop-qfs/src/test/java/com/quantcast/qfs/hadoop/QFSEmulationImpl.java
@@ -208,6 +208,13 @@ public class QFSEmulationImpl implements IFSImpl {
     return localFS.create(new Path(path));
   }
 
+  public FSDataOutputStream create(String path, boolean overwrite,
+          String createParams) throws IOException {
+      // besides path/overwrite, the other args don't matter for
+      // testing purposes.
+      return localFS.create(new Path(path));
+  }
+
   public FSDataInputStream open(String path, int bufferSize)
     throws IOException {
     return localFS.open(new Path(path));

--- a/src/java/qfs-access/src/main/java/com/quantcast/qfs/access/KfsAccess.java
+++ b/src/java/qfs-access/src/main/java/com/quantcast/qfs/access/KfsAccess.java
@@ -97,7 +97,10 @@ final public class KfsAccess
     private final static native
     int create(long ptr, String path, int numReplicas, boolean exclusive,
         int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
-        boolean forceType, int mode);
+        boolean forceType, int mode, int minSTier, int maxSTier);
+
+    private final static native
+    int create2(long ptr, String path, boolean exclusive, String createParams);
 
     private final static native
     int remove(long ptr, String path);
@@ -558,8 +561,21 @@ final public class KfsAccess
             int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
             boolean forceType, int mode) throws IOException
     {
+        int minSTier = 15;
+        int maxSTier = 15;
+        return kfs_create_ex(path, numReplicas, exclusive, bufferSize, readAheadSize,
+                numStripes, numRecoveryStripes, stripeSize, stripedType, forceType,
+                mode, minSTier, maxSTier);
+    }
+
+    public KfsOutputChannel kfs_create_ex(String path, int numReplicas, boolean exclusive,
+            long bufferSize, long readAheadSize,
+            int numStripes, int numRecoveryStripes, int stripeSize, int stripedType,
+            boolean forceType, int mode, int minSTier, int maxSTier) throws IOException
+    {
         final int fd = create(cPtr, path, numReplicas, exclusive,
-                numStripes, numRecoveryStripes, stripeSize, stripedType, forceType, mode);
+                numStripes, numRecoveryStripes, stripeSize, stripedType, forceType,
+                mode, minSTier, maxSTier);
         kfs_retToIOException(fd, path);
         if (bufferSize >= 0) {
             setIoBufferSize(cPtr, fd, bufferSize);
@@ -567,6 +583,23 @@ final public class KfsAccess
         if (readAheadSize >= 0) {
             setReadAheadSize(cPtr, fd, readAheadSize);
         }
+        KfsOutputChannel chan = null;
+        try {
+            final boolean append = false;
+            chan = new KfsOutputChannel(this, fd, append);
+        } finally {
+            if (chan == null) {
+                close(cPtr, fd);
+            }
+        }
+        return chan;
+    }
+
+    public KfsOutputChannel kfs_create_ex(String path, boolean exclusive,
+            String createParams) throws IOException
+    {
+        final int fd = create2(cPtr, path, exclusive, createParams);
+        kfs_retToIOException(fd, path);
         KfsOutputChannel chan = null;
         try {
             final boolean append = false;


### PR DESCRIPTION
Currently, KfsAccess java library uses the default values for create parameters such as number of stripes, number of recovery stripes, stripe size... This change lets the user pass a string value that specifies create parameters for a new file.
