### PR TITLE
allow environment variables in .prp files (QFS-318)

### DIFF
--- a/src/cc/common/Properties.cc
+++ b/src/cc/common/Properties.cc
@@ -181,6 +181,21 @@ Properties::loadProperties(
         }
         removeLTSpaces(line, 0, pos, key, keysAsciiToLower);
         removeLTSpaces(line, pos + 1, string::npos, val);
+        // if val starts with "$", read the value from the
+        // specified environment variable
+        if((val.c_str())[0] == '$') {
+            const char* envVarName = &(val.c_str())[1];
+            char* envVarVal = getenv(envVarName);
+            if (!envVarVal) {
+                if (verbose) {
+                    (*verbose) << "Skipping key " << key <<
+                            " since $" << envVarName <<
+                            " is not defined " << endl;
+                }
+                continue;
+            }
+            val.Copy(String(envVarVal));
+        }
         if (multiline) {
             // allow properties to span across multiple lines
             propmap[key].Append(val);

--- a/src/cc/tests/CMakeLists.txt
+++ b/src/cc/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(test_sources
     environments/MetaserverEnvironment.cc
     environments/ChunkserverEnvironment.cc
 
+    common/Properties_T.cc
     common/Test_T.cc
 )
 

--- a/src/cc/tests/common/Properties_T.cc
+++ b/src/cc/tests/common/Properties_T.cc
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include "common/Properties.h"
+#include "tests/integtest.h"
+
+#include <string>
+#include <stdlib.h>
+
+using std::cout;
+using std::endl;
+using std::string;
+using KFS::Properties;
+using KFS::Test::QFSTestUtils;
+
+TEST(LoadPropertiesTest, LoadFromEnvVariable) {
+
+	string confStr = "fieldA = $QFS_ENV_VAR_FIELD_A\n";
+	confStr       += "fieldB = $QFS_ENV_VAR_FIELD_B\n";
+
+	int ret = setenv("QFS_ENV_VAR_FIELD_A", "field_value", 1);
+	if(ret == -1) {
+		cout << "Can't set the environment variable. Test is skipped." << endl;
+		return;
+	}
+
+	string filePath = QFSTestUtils::WriteTempFile(confStr);
+	Properties p;
+	p.loadProperties(filePath.c_str(), '=');
+	ASSERT_STREQ(p.getValue("fieldA", ""), "field_value");
+	ASSERT_STREQ(p.getValue("fieldB", ""), "");
+
+	QFSTestUtils::RemoveForcefully(filePath);
+}


### PR DESCRIPTION
This change allows users to specify environment variables in .prp configuration files. For instance, for a chunkserver, one can have a line like the following to set the "chunkServer.chunkDir" attribute:

`chunkServer.chunkDir = $CHUNKDIRS`

Note that this change assumes that environment variables start with the "$" sign. If an environment variable is not actually set, the current logic skips loading a value for the corresponding attribute.