### PR TITLE
remove unneeded chunkserver parameters from sample_setup script

### DIFF
--- a/examples/sampleservers/sample_setup.py
+++ b/examples/sampleservers/sample_setup.py
@@ -571,8 +571,6 @@ def setup_config_files(config, authFlag, osFlag):
                 print >> chunkFile, 'chunkServer.clusterKey = %s' % clusterKey
                 print >> chunkFile, 'chunkServer.rackId = 0'
                 print >> chunkFile, 'chunkServer.chunkDir = %s' % chunkDirs
-                print >> chunkFile, 'chunkServer.diskIo.crashOnError = 1'
-                print >> chunkFile, 'chunkServer.abortOnChecksumMismatchFlag = 1'
                 print >> chunkFile, 'chunkServer.msgLogWriter.logLevel = DEBUG'
                 print >> chunkFile, 'chunkServer.msgLogWriter.maxLogFileSize = 1e6'
                 print >> chunkFile, 'chunkServer.msgLogWriter.maxLogFiles = 2'


### PR DESCRIPTION
chunkServer.diskIo.crashOnError and chunkServer.abortOnChecksumMismatchFlag are not crucial for sample_setup script, which is used to install/uninstall an local QFS instance with minimum effort. Removing them from the script will make the generated configuration files more concise.