### PR TITLE
QFS-325 Throw exception if native code load fails instead of calling exit

### DIFF
--- a/src/java/qfs-access/src/main/java/com/quantcast/qfs/access/KfsAccess.java
+++ b/src/java/qfs-access/src/main/java/com/quantcast/qfs/access/KfsAccess.java
@@ -232,9 +232,7 @@ final public class KfsAccess
         try {
             System.loadLibrary("qfs_access");
         } catch (UnsatisfiedLinkError e) {
-            e.printStackTrace();
-            System.err.println("Unable to load qfs_access native library");
-            System.exit(1);
+            throw new RuntimeException("Unable to load qfs_access native library", e);
         }
     }
 


### PR DESCRIPTION
If the kfsaccess native code fails to load, the current reaction is to dump a stacktrace and call System.exit.

This is rather unfriendly and can make it hard to diagnose the issue in situations where syserr output is not easily available. It also prevents any attempt to probe for qfs availability.

This code will now throw an exception instead.

@mikeov  @mckurt 