### PR TITLE
QFS-332 - make QuantcastFileSystem honor umask setting from jobconf for better Hadoop/Hive compatility

### DIFF
--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/IFSImpl.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/IFSImpl.java
@@ -77,6 +77,8 @@ interface IFSImpl {
            throws IOException;
   public void retToIoException(int ret)
            throws IOException;
+  public int getUMask() throws IOException;
+  public void setUMask(int mask) throws IOException;
   public CloseableIterator<FileStatus> getFileStatusIterator(FileSystem fs, Path path)
            throws IOException;
 };

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSImpl.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QFSImpl.java
@@ -282,6 +282,16 @@ class QFSImpl implements IFSImpl {
       path, username, groupname), path);
   }
 
+  public int getUMask()
+    throws IOException {
+    return kfsAccess.kfs_getUMask();
+  }
+
+  public void setUMask(int mask)
+    throws IOException {
+    kfsAccess.kfs_setUMask(mask);
+  }
+
   public void retToIoException(int ret)
     throws IOException {
     kfsAccess.kfs_retToIOException(ret);

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
@@ -83,6 +83,7 @@ public class QuantcastFileSystem extends FileSystem {
           (uri.getAuthority() == null ? "/" : uri.getAuthority()));
       this.workingDir = new Path("/user", System.getProperty("user.name")
                                 ).makeQualified(uri, null);
+      this.qfsImpl.setUMask(FsPermission.getUMask(conf).toShort());
     } catch (Exception e) {
       throw new IOException("Unable to initialize QFS using uri " + uri);
     }

--- a/src/java/hadoop-qfs/src/test/java/com/quantcast/qfs/hadoop/QFSEmulationImpl.java
+++ b/src/java/hadoop-qfs/src/test/java/com/quantcast/qfs/hadoop/QFSEmulationImpl.java
@@ -35,9 +35,11 @@ import com.quantcast.qfs.access.KfsFileAttr;
 
 public class QFSEmulationImpl implements IFSImpl {
   FileSystem localFS;
+  int umask;
 
   public QFSEmulationImpl(Configuration conf) throws IOException {
     localFS = FileSystem.getLocal(conf);
+    umask = FsPermission.getUMask(conf).toShort();
   }
 
   public boolean exists(String path) throws IOException {
@@ -232,6 +234,16 @@ public class QFSEmulationImpl implements IFSImpl {
   public void setOwner(String path, String username, String groupname)
     throws IOException {
     localFS.setOwner(new Path(path), username, groupname);
+  }
+
+  public void setUMask(int mask)
+    throws IOException {
+    umask = mask;
+  }
+
+  public int getUMask()
+    throws IOException {
+    return umask;
   }
 
   public CloseableIterator<FileStatus> getFileStatusIterator(FileSystem fs, Path path)


### PR DESCRIPTION
This change makes a QuantcastFileSystem instance fetch the standard Hadoop umask value from the Configuration used when the instance is created then sets that umask value in its client.

This will improve general Hadoop compatibility.

It also eliminates a problem with Spark and Hive when QFS is set as the default filesystem.

Hive needs to create a /tmp/hive directory with a permission of 777 so it can create user-specific subdirectories. It creates a new instance of the default filesystem with the standard Hadoop umask property set to 000, tries to create the /tmp/hive directory, then checks that the directory had the correct permissions.

Before this change, QuantcatFileSystem was ignoring the umask property and Hive would complain that that /tmp/hive was not world-writable.  With this change, Hive can create the directory properly.

@mikeov @mckurt 