### PR TITLE
Add build for Hadoop 2.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ hadoop-jars: build java
 		./src/java/javabuild.sh 0.23.11 && \
 		./src/java/javabuild.sh 1.0.4   && \
 		./src/java/javabuild.sh 1.1.2   && \
-		./src/java/javabuild.sh 2.5.1      \
+		./src/java/javabuild.sh 2.5.1   && \
+		./src/java/javabuild.sh 2.7.2      \
 	; fi
 
 .PHONY: tarball


### PR DESCRIPTION
Spark is bundling with Hadoop 2.7.2.

Added a build of the java hadoop shim for 2.7.2

@mikeov @mckurt 