### PR TITLE
Hadoop shim: added calls to checkPath to check fully-qualified path inputs are for the correct filesystem

### DIFF
--- a/src/java/hadoop-qfs-2/src/main/java/com/quantcast/qfs/hadoop/Qfs.java
+++ b/src/java/hadoop-qfs-2/src/main/java/com/quantcast/qfs/hadoop/Qfs.java
@@ -104,6 +104,7 @@ public class Qfs extends AbstractFileSystem {
     boolean             createParent)
       throws IOException {
     CreateFlag.validate(createFlag);
+    checkPath(path);
     if (createParent) {
       mkdir(path.getParent(), absolutePermission, createParent);
     }
@@ -186,6 +187,7 @@ public class Qfs extends AbstractFileSystem {
   @Override
   public void mkdir(Path dir, FsPermission permission, boolean createParent)
       throws IOException, UnresolvedLinkException {
+    checkPath(dir);
     qfsImpl.retToIoException(
       createParent ?
         qfsImpl.mkdirs(getUriPath(dir), permission.toShort()) :
@@ -203,6 +205,8 @@ public class Qfs extends AbstractFileSystem {
   public void renameInternal(Path src, Path dst)
       throws IOException, UnresolvedLinkException {
     final boolean kOverwriteDestinationFlag = false;
+    checkPath(src);
+    checkPath(dst);
     qfsImpl.retToIoException(
       qfsImpl.rename2(getUriPath(src), getUriPath(dst),
         kOverwriteDestinationFlag)

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
@@ -108,6 +108,7 @@ public class QuantcastFileSystem extends FileSystem {
 
   protected Path makeAbsolute(Path path) throws IOException {
     if (path.isAbsolute()) {
+      checkPath(path);
       return path;
     }
     if (null == workingDir) {


### PR DESCRIPTION
The Hadoop shim for QFS was not checking that that fully qualified path arguments were for the correct FileSystem instance.

For example,

URI uri = URI.create("qfs://ms1.example.com:10000");
FileSystem fs = FileSystem.get(uri, new Configuration());
FileStatus[] otherQFSList = fs.listStatus(new Path("qfs://ms2.example.com:20000/"));
FileStatus[] otherQFSList = fs.listStatus(new Path("hdfs://127.0.0.1:20000/"));

will return a listing of the root of the filesystem at ms1.example.com:10000 in both cases

This can cause confusion, especially in contexts when the association between filesystems objects and paths may be a bit more obscure. Some Spark users have been thrown by this behavior.

The base FileSystem class provides a checkPath(Path) method to check that if a path is fully qualified, then the filesystem it specifies is the same as the FileSystem instance being used.

This fix adds calls to checkPath where needed. Almost all the methods that take a Path argument call makeAbsolute or something that calls makeAbsolute so adding the check there covered most of the cases.

Note that HDFS and many other Hadoop Filesystems perform a similar check.

@mikeov @mckurt 