### PR TITLE
Fix errors and warnings from GCC 7.2

### DIFF
--- a/src/cc/common/BufferedLogWriter.cc
+++ b/src/cc/common/BufferedLogWriter.cc
@@ -893,8 +893,9 @@ private:
         {
             char* const theEndPtr = epptr();
             char* const theCurPtr = pptr();
-            const streamsize theSize(min(max(streamsize(0), inLength),
-                streamsize(theEndPtr - theCurPtr)));
+            const streamsize theSize(
+                max(streamsize(0),
+                    min(inLength, streamsize(theEndPtr - theCurPtr))));
             memcpy(theCurPtr, inBufPtr, theSize);
             pbump(theSize);
             return (mTeeStreamPtr ?

--- a/src/cc/common/StBuffer.h
+++ b/src/cc/common/StBuffer.h
@@ -155,7 +155,7 @@ public:
         size_t inIndex) const
         { return mBufPtr[inIndex]; }
     void Swap(
-        const StBufferT& inBuf)
+        StBufferT& inBuf)
     {
         if (mBufPtr != mBuf) {
             if (inBuf.mBufPtr != inBuf.mBuf) {

--- a/src/cc/meta/LayoutManager.cc
+++ b/src/cc/meta/LayoutManager.cc
@@ -3259,15 +3259,15 @@ protected:
     CtrWriteExtra()
         : mBufEnd(mBuf + kBufSize)
         {}
-    const Properties::String& BoolToString(bool flag) const
-    {
-        return (flag ? kTrueStr : kFalseStr);
-    }
     template<typename T>
     void Write(IOBufferWriter& writer, T val)
     {
         const char* const b = IntToDecString(val, mBufEnd);
         writer.Write(b, mBufEnd - b);
+    }
+    void Write(IOBufferWriter& writer, bool val)
+    {
+        writer.Write(val ? kTrueStr : kFalseStr);
     }
 
     enum { kBufSize = 32 };
@@ -3347,11 +3347,11 @@ struct CSWriteExtra : public CtrWriteExtra
         writer.Write(columnDelim);
         writer.Write(srv.GetHostPortStr());
         writer.Write(columnDelim);
-        writer.Write(BoolToString(srv.IsRetiring()));
+        Write(writer, srv.IsRetiring());
         writer.Write(columnDelim);
-        writer.Write(BoolToString(srv.IsRestartScheduled()));
+        Write(writer, srv.IsRestartScheduled());
         writer.Write(columnDelim);
-        writer.Write(BoolToString(srv.IsResponsiveServer()));
+        Write(writer, srv.IsResponsiveServer());
         writer.Write(columnDelim);
         Write(writer, srv.GetAvailSpace());
         writer.Write(columnDelim);


### PR DESCRIPTION
* `StBuffer::Swap(StBufferT& inBuf)` cannot take const argument
* `MessageStream::xsputn` memcpys at least 0 bytes
* `LayoutManager::CSWriteExtra::Write()` handles bool