### PR TITLE
Add Go bindings

### DIFF
--- a/src/go/README.md
+++ b/src/go/README.md
@@ -1,0 +1,47 @@
+Go QFS Bindings
+===============
+
+These are Go bindings to interact with [Quantcast File System](https://github.com/quantcast/qfs).
+It includes many of the common functions exported by the QFS API.
+
+Build and Test
+--------------
+
+Several incantations of the compiler flags and the linker are required to get
+qfs to compile against the c library. We may be to remove this necessity with
+static linking but time is short.
+
+Some incantation such as this should work:
+
+Should be the path to your qfs build or production qfs.
+
+Here are the environment variables I've used to compile these (Mac OS X specific):
+
+	export QFS_RELEASE=/Users/sday/c/qfs/build/release
+	export DYLD_LIBRARY_PATH=$QFS_RELEASE/lib/
+	export CGO_CFLAGS=-I$QFS_RELEASE/include/
+	export CGO_LDFLAGS=-L$QFS_RELEASE/lib
+
+Note that these are Mac OSX specific, but are nearly identical for a linux
+system. Just changing DYLD_LIBRARY_PATH to LD_LIBRARY_PATH should work.
+DYLD_LIBRARY_PATH/LD_LIBRARY_PATH may not be necessary with proper linking.
+
+This let's one run the standard go commands:
+
+	go build
+	go install goget.corp.qc/go/qfs
+
+Even testing works, with the sample server in the main project, assuming
+QFS_SOURCE environment variable is set to the source checkout of qfs:
+
+	python $QFS_SOURCE/examples/sampleservers/sample_setup.py -a install
+	python $QFS_SOURCE/examples/sampleservers/sample_setup.py -a start
+	go test -qfs.addr localhost:20000
+
+Caveats
+-------
+
+- The locking may be slightly course-grained.
+- There are several easy performance enhancements that can be gained by
+  eliminating redundant calls to QFS client library and through aggressive
+  caching.

--- a/src/go/error.go
+++ b/src/go/error.go
@@ -1,0 +1,73 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package qfs
+
+// #cgo LDFLAGS: -lqfsc
+//
+//#include <stdlib.h>
+//#include <kfs/c/qfs.h>
+//
+import "C"
+import (
+	"fmt"
+	"syscall"
+)
+
+// Error encapsulates the error return values form QFS operations.  A call
+// to the QFS API is used to generate a human readable string from the error
+// code.  The error codes are generally the same as standard unix codes, and
+// this type can be compared to those values to determine the cause of an error
+// when necessary.
+type Error struct {
+	Err syscall.Errno
+}
+
+func (e Error) Error() string {
+	var buf [256]C.char
+	return fmt.Sprintf("qfs error: %s", C.GoString(C.qfs_strerror(
+		C.int(e.Err)*-1,
+		(*C.char)(&buf[0]),
+		C.size_t(len(buf)),
+	)))
+}
+
+func errFromQfs(code C.int) error {
+	if code < 0 {
+		code = -code
+	}
+	return &Error{syscall.Errno(code)}
+}
+
+// IsQfsErrorCode returns if the error is for the specified error code
+// (syscall.Errno)
+func IsQfsErrorCode(err error, code syscall.Errno) bool {
+	e, ok := err.(*Error)
+	return ok && e.Err == code
+}
+
+// ErrPartialWrite is thrown when not all of the bytes given to a File.Write
+// call are written to QFS.
+type ErrPartialWrite struct {
+	written int
+	total   int
+	path    string
+}
+
+func (e ErrPartialWrite) Error() string {
+	return fmt.Sprintf("only wrote %d out of %d bytes to %s", e.written,
+		e.total, e.path)
+}

--- a/src/go/file.go
+++ b/src/go/file.go
@@ -1,0 +1,325 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package qfs
+
+// #cgo LDFLAGS: -lqfsc
+//
+//#include <stdlib.h>
+//#include <kfs/c/qfs.h>
+//
+import "C"
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"unsafe"
+)
+
+// File represents a file in QFS that can be operated on.
+type File struct {
+	qfs  *Client
+	fd   C.int
+	path string // Hold onto the opening path. Shouldn't be an issue with qfs.
+	m    sync.Mutex
+
+	rfr   rawFileReader
+	buf   *bufio.Reader
+	dirty bool // Set this after a read to signal that seek should reset the buffer.
+
+	// iter manages re-entrant directory traversal
+	iter *C.struct_qfs_iter
+
+	closed bool
+}
+
+// Initializes a new file from the specified file descriptor and path.  The
+// reading is wrapped by a bufio.Reader, which is allocated from a pool
+// maintained in the Client.
+func newFile(qfs *Client, fd C.int, path string) *File {
+	// This makes reads a little more robust. Maybe this isn't correct but it
+	// doesn't seem to hurt.
+	C.qfs_set_skipholes(qfs.qfs, fd)
+
+	f := &File{
+		qfs:  qfs,
+		fd:   fd,
+		path: path,
+	}
+
+	f.rfr.f = f
+
+	// Setup the buffered reader.
+	if buf := qfs.buffers.Get(); buf != nil {
+		f.buf = buf.(*bufio.Reader)
+		f.buf.Reset(f.rfr) // Set the buffer to read from the QFS file.
+	} else {
+		f.buf = bufio.NewReaderSize(f.rfr,
+			// Just set the Go buffered reader size to match the internal
+			// buffer size of the qfs client. This ensures that we copy all
+			// the client-side data over to the go side, minimizing the number
+			// of cgo calls made to qfs.
+			int(C.qfs_get_iobuffersize(f.qfs.qfs, f.fd)))
+	}
+
+	return f
+}
+
+// TODO(sday): Right now, locking is pretty course grained to prevent race
+// conditions. Once we have time to optimize, many of these locks should be
+// released while issuing calls out to cgo that might block while waiting for
+// qfs io. Essentially, we need to arrange it such that we defer concurrency
+// management to the qfs library, where possible. This may not be an issue for
+// Files, as they should generally not be shared among goroutines.
+
+// Close the file. Calling this method after the file is already closed will
+// not throw any errors.
+func (f *File) Close() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	return f.close()
+}
+
+// Stat returns an FileInfo struct representing details about the underlying
+// file.
+func (f *File) Stat() (os.FileInfo, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	return f.stat()
+}
+
+// Readdir reads the contents of the directory associated with file and returns
+// a slice of up to n FileInfo values, as would be returned by Lstat, in
+// directory order. Subsequent calls on the same file will yield further FileInfos.
+func (f *File) Readdir(count int) ([]os.FileInfo, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if f.closed {
+		// Return EOF when directory is closed.
+		return nil, io.EOF
+	}
+
+	var entries []os.FileInfo
+	var attr C.struct_qfs_attr
+
+	// We use count == 0 for the breaking value in the loop below. To meet the
+	// Readdir interface, we must return all entries if count <= 0 is passed
+	// in, so we fix up count to zero.
+	if count <= 0 {
+		count = -1
+	}
+
+	for count != 0 {
+		cpath := C.CString(f.path)
+		defer freeCString(cpath)
+
+		left := C.qfs_readdir(f.qfs.qfs, cpath, &f.iter, &attr)
+		if left < 0 {
+			return nil, errFromQfs(left)
+		}
+
+		if left == 0 {
+			// Since we have a directory, we need to mimic readdir being
+			// single flight. File will be closed after read is completed.
+			if err := f.close(); err != nil {
+				return nil, err
+			}
+
+			break
+		}
+
+		fi := newFileInfo(attr)
+		fname := fi.Name()
+
+		if fname != "." && fname != ".." { // These should not be in directory listings
+			entries = append(entries, fi)
+			count--
+		}
+	}
+
+	return entries, nil
+}
+
+// Read all the bytes from p and write them to the file.
+func (f *File) Read(p []byte) (int, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	f.dirty = true
+
+	return f.buf.Read(p)
+}
+
+// Seek changes the current position in the file to the specified offset.
+// See https://golang.org/pkg/io/#pkg-constants for the various options for
+// `whence`
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	// off_t qfs_seek(struct QFS* qfs, int fd, off_t offset, int whence);
+	noffset := C.qfs_seek(f.qfs.qfs, f.fd, C.off_t(offset), C.int(whence))
+
+	if noffset < 0 {
+		return 0, errFromQfs(C.int(noffset))
+	}
+
+	if f.dirty {
+		// Reset the buffer state after a seek.
+		f.buf.Reset(f.rfr)
+		f.dirty = false
+
+		// BUG(sday): Clearing out this buffer is *not* the correct action if
+		// the seek doesn't break the bounds of the buffer. This issue was
+		// detected because the http.FileSystem implementation does a Read on
+		// the start of the file to sniff the content type, then seeks back to
+		// 0 to enable the main read. Because the buffer is reset, the round
+		// trip (either cgo -> KfsClient or on the network) is issued a second
+		// time. This negatively affects fetch performance for small files.
+	}
+
+	return int64(noffset), nil
+}
+
+// Write len(p) bytes from p to the file.  Implements io.Writer.
+func (f *File) Write(p []byte) (int, error) {
+	// Check that the data to write isn't empty
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	n := int(C.qfs_write(f.qfs.qfs, f.fd, unsafe.Pointer(&p[0]), C.size_t(len(p))))
+
+	// Return a QFS error if n < 0, or a ErrPartialWrite if n < len(p)
+	if n < 0 {
+		return n, errFromQfs(C.int(n))
+	} else if n < len(p) {
+		return n, &ErrPartialWrite{written: n, total: len(p), path: f.path}
+	}
+
+	return n, nil
+}
+
+// WriteAt writes len(p) bytes from p to the file at the absolute address off.
+// The current position of the file does not affect this method.  Implements
+// io.WriterAt.
+func (f *File) WriteAt(p []byte, off int64) (int, error) {
+	// Check that the data to write isn't empty
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	n := int(C.qfs_pwrite(f.qfs.qfs, f.fd, unsafe.Pointer(&p[0]),
+		C.size_t(len(p)), C.off_t(off)))
+
+	// Return a QFS error if n < 0, or a ErrPartialWrite if n < len(p)
+	if n < 0 {
+		return n, errFromQfs(C.int(n))
+	} else if n < len(p) {
+		return n, &ErrPartialWrite{written: n, total: len(p), path: f.path}
+	}
+
+	return n, nil
+}
+
+// Sync forces the written data to be synced out to the chunk servers.
+func (f *File) Sync() error {
+	res := C.qfs_sync(f.qfs.qfs, f.fd)
+	if res < 0 {
+		return errFromQfs(res)
+	}
+	return nil
+}
+
+// Name returns the name (or path) to the file as given in the Client.Open call.
+func (f *File) Name() string {
+	return f.path
+}
+
+func (f *File) close() error {
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+
+	if ec := C.qfs_close(f.qfs.qfs, f.fd); ec < 0 {
+		return errFromQfs(ec)
+	}
+
+	C.qfs_iter_free(&f.iter)
+
+	// Return the buffer to the pool
+	f.qfs.buffers.Put(f.buf)
+	f.buf = nil
+
+	return nil
+}
+
+func (f *File) stat() (*FileInfo, error) {
+	var attr C.struct_qfs_attr
+
+	ec := C.qfs_stat_fd(f.qfs.qfs, f.fd, &attr)
+
+	if ec < 0 {
+		return nil, errFromQfs(ec)
+	}
+
+	return newFileInfo(attr), nil
+}
+
+// This is an internal type necessary for being able to define a Read
+// method on the QFS file that actually uses the API.  The Read method on File
+// should instead use the buffered reader that wraps this type.
+type rawFileReader struct {
+	f *File
+}
+
+func (rfr rawFileReader) Read(p []byte) (int, error) {
+	n := int(C.qfs_read(rfr.f.qfs.qfs, rfr.f.fd, unsafe.Pointer(&p[0]), C.size_t(len(p))))
+
+	if n < 0 {
+		return 0, errFromQfs(C.int(n))
+	}
+
+	if n == 0 {
+		// HACK(sday): If the reads start returning 0, return EOF when the
+		// seek position equals the file size. This may not be right under all
+		// conditions, but should prevent issues with sparse files not
+		// returning EOF on the last read.
+
+		fi, err := rfr.f.stat()
+		if err != nil {
+			return 0, fmt.Errorf("error checking file size while reading: %s", err)
+		}
+
+		if int64(C.qfs_tell(rfr.f.qfs.qfs, rfr.f.fd)) == fi.Size() {
+			return 0, io.EOF
+		}
+	}
+
+	return n, nil
+}

--- a/src/go/file_test.go
+++ b/src/go/file_test.go
@@ -1,0 +1,281 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package qfs
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestFile_ReadWrite(t *testing.T) {
+	qfs := initQfs(t)
+
+	file, err := qfs.OpenFile("/test", os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	testData := "test string"
+	_, err = io.WriteString(file, testData)
+	if err != nil {
+		t.Fatalf("Failed to write to %v: %v", file, err)
+	}
+	file.Close()
+
+	file, err = qfs.OpenFile("/test", os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read from %s: %v", file.path, err)
+	}
+
+	if string(data) != testData {
+		t.Errorf("Got the wrong data\nExpected: %s\tActual: %s", testData,
+			string(data))
+	}
+}
+
+func TestFile_WriteAt(t *testing.T) {
+	qfs := initQfs(t)
+
+	file, err := qfs.OpenFile("/test", os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	testData := "test  string"
+	_, err = io.WriteString(file, testData)
+	if err != nil {
+		t.Fatalf("Failed to write to %v: %v", file, err)
+	}
+	file.Close()
+
+	file, err = qfs.OpenFile("/test", os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	offset := int64(4)
+	_, err = file.WriteAt([]byte("ed"), offset)
+	if err != nil {
+		t.Fatalf("Failed to write to %v at %d: %v", file, offset, err)
+	}
+	file.Close()
+
+	file, err = qfs.OpenFile("/test", os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read from %s: %v", file.path, err)
+	}
+
+	expected := "testedstring"
+	if string(data) != expected {
+		t.Errorf("Got the wrong data\nExpected: %s\tActual: %s", expected,
+			string(data))
+	}
+}
+
+// Test that writing an array of empty bytes doesn't panic
+func TestFile_EmptyWrite(t *testing.T) {
+	qfs := initQfs(t)
+	fpath := path.Join(testDir, "empty_write_test")
+
+	file, err := qfs.OpenFile(fpath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	_, err = file.Write([]byte{})
+	if err != nil {
+		t.Fatalf("Failed to write to %v: %v", file, err)
+	}
+}
+
+func TestFile_Seek(t *testing.T) {
+	qfs := initQfs(t)
+	fpath := path.Join(testDir, "empty_write_test")
+
+	file, err := qfs.OpenFile(fpath, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	testData := "test string"
+	_, err = io.WriteString(file, testData)
+	if err != nil {
+		t.Fatalf("Failed to write to %v: %v", file, err)
+	}
+	file.Close()
+
+	file, err = qfs.Open(fpath)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	offset := int64(5)
+	newOffset, err := file.Seek(offset, os.SEEK_SET)
+	if err != nil {
+		t.Fatalf("Failed to seek to %d in %v: %v", offset, file, err)
+	}
+
+	if offset != newOffset {
+		t.Errorf("The new offset %d should've been %d", newOffset, offset)
+	}
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read from %s: %v", file.path, err)
+	}
+
+	expected := "string"
+	if string(data) != expected {
+		t.Errorf("Got the wrong data\nExpected: %s\tActual: %s", expected,
+			string(data))
+	}
+}
+
+func ExampleFile_Readdir() {
+	qfs, _ := Dial(addr)
+
+	file, err := qfs.Open("/")
+	if err != nil {
+		return
+	}
+
+	// Read all fo the fileinfos in the directory
+	infos, err := file.Readdir(-1)
+
+	for _, info := range infos {
+		// Operate on the fileinfo...
+		fmt.Printf("Found file: %s", info.Name())
+	}
+}
+
+func TestFile_Readdir(t *testing.T) {
+	qfs := initQfs(t)
+
+	files := []string{"test_file1", "t2", "test3"}
+
+	// construct the files
+	for i := range files {
+		file, err := qfs.OpenFile(path.Join(testDir, files[i]),
+			os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("Failed to open file %s: %v", files[i], err)
+		}
+
+		_, err = io.WriteString(file, "test")
+		if err != nil {
+			t.Fatalf("Failed to write to %s: %v", files[i], err)
+		}
+
+		file.Close()
+	}
+
+	// Verify that all files are shown in Readdir
+	dir, err := qfs.Open(testDir)
+	if err != nil {
+		t.Fatalf("Failed to open %s: %v", testDir, err)
+	}
+	defer dir.Close()
+
+	infos, err := dir.Readdir(-1)
+	if err != nil {
+		t.Fatalf("Readdir failed: %v", err)
+	}
+
+	checkFunc := func(file string, infos []os.FileInfo) bool {
+		for _, info := range infos {
+			if file == info.Name() {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, file := range files {
+		if !checkFunc(file, infos) {
+			t.Errorf("Didn't find %s in the output of Readdir: %v", file, infos)
+		}
+	}
+
+	// Delete the files
+	for i := range files {
+		err := qfs.Remove(path.Join(testDir, files[i]))
+		if err != nil {
+			t.Fatalf("Failed to delete file %s: %v", files[i], err)
+		}
+	}
+}
+
+func TestFile_DirtySeek(t *testing.T) {
+	qfs := initQfs(t)
+	fpath := path.Join(testDir, "dirty_seek")
+
+	file, err := qfs.OpenFile(fpath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Failed to open file %s: %v", fpath, err)
+	}
+
+	testData := "test data"
+	_, err = io.WriteString(file, testData)
+	if err != nil {
+		t.Fatalf("Failed to write to %s: %v", fpath, err)
+	}
+	file.Close()
+
+	// Read the file with a dirty seek
+	file, err = qfs.Open(fpath)
+	if err != nil {
+		t.Fatalf("Failed to open file %s: %v", fpath, err)
+	}
+
+	buf := make([]byte, 3)
+	if _, err := file.Read(buf); err != nil {
+		t.Fatalf("Failed to read from %s: %v", fpath, err)
+	}
+
+	index, err := file.Seek(2, os.SEEK_SET)
+	if err != nil {
+		t.Fatalf("Failed to seek: %v", err)
+	} else if index != 2 {
+		t.Errorf("The index should be %d but is %d", 2, index)
+	}
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read from %s: %v", fpath, err)
+	}
+
+	expected := testData[2:]
+	if expected != string(data) {
+		t.Errorf("Got the wrong result from read\nExpected: %s\nActual: %s",
+			expected, data)
+	}
+}

--- a/src/go/fileinfo.go
+++ b/src/go/fileinfo.go
@@ -1,0 +1,130 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package qfs
+
+// #cgo LDFLAGS: -lqfsc
+//
+//#include <stdlib.h>
+//#include <kfs/c/qfs.h>
+//
+import "C"
+import (
+	"os"
+	"path"
+	"time"
+)
+
+// FileInfo provides information about a specific file in QFS.  This implements
+// os.FileInfo (https://golang.org/pkg/os/#FileInfo) and therefore provides
+// the following methods:
+//
+// Name() string         base name of the file
+// Size() int64          length in bytes for regular files
+// Mode() FileMode       file mode bits
+// ModTime() time.Time   modification time
+// IsDir() bool          abbreviation for Mode().IsDir()
+// Sys() interface{}     a FileInfoAttr struct
+type FileInfo struct {
+	Attr *FileInfoAttr
+}
+
+var _ os.FileInfo = &FileInfo{}
+
+func newFileInfo(attr C.struct_qfs_attr) *FileInfo {
+	return &FileInfo{Attr: newFileInfoAttr(attr)}
+}
+
+// Name returns the base name of the file
+func (fi *FileInfo) Name() string {
+	return path.Base(fi.Attr.Path)
+}
+
+// Size returns the size in bytes of the file.
+func (fi *FileInfo) Size() int64 {
+	return int64(fi.Attr.Size)
+}
+
+// Mode returns an os.FileMode for the mode of the file.
+func (fi *FileInfo) Mode() os.FileMode {
+	return fi.Attr.Mode
+}
+
+// ModTime returns the time last modified.
+func (fi *FileInfo) ModTime() time.Time {
+	return fi.Attr.Mtime
+}
+
+// IsDir returns true if this FileInfo is on a directory
+func (fi *FileInfo) IsDir() bool {
+	return fi.Attr.IsDirectory
+}
+
+// Sys returns a qfs_attr struct which contains additional details about the
+// file.  The fields exposed by the qfs_attr struct are detailed at
+// https://github.com/quantcast/qfs/blob/9f6b4887b6fe60ee06e39bacf7fa2e14436bf5b0/src/cc/qfsc/qfs.h#L48
+func (fi *FileInfo) Sys() interface{} {
+	return fi.Attr
+}
+
+func timevalToTime(tval C.struct_timeval) time.Time {
+	return time.Unix(
+		int64(tval.tv_sec),
+		int64(tval.tv_usec)*int64(time.Microsecond))
+}
+
+// FileInfoAttr exposes the underlying qfs_attr struct for more information if needed.
+// You can see https://github.com/quantcast/qfs/blob/9f6b4887b6fe60ee06e39bacf7fa2e14436bf5b0/src/cc/qfsc/qfs.h#L48
+// for more information on the meaning of the fields.
+type FileInfoAttr struct {
+	Path            string
+	UID             uint64
+	GID             uint64
+	Mode            os.FileMode
+	Inode           int64
+	Mtime           time.Time
+	Ctime           time.Time // attribute change time
+	CRtime          time.Time // creation time
+	IsDirectory     bool
+	Size            uint64
+	Chunks          uint64
+	Directories     uint64
+	Replicas        int16
+	Stripes         int16
+	RecoveryStripes int16
+	StripeSize      int32
+}
+
+func newFileInfoAttr(attr C.struct_qfs_attr) *FileInfoAttr {
+	return &FileInfoAttr{
+		Path:            C.GoString(&attr.filename[0]),
+		UID:             uint64(attr.uid),
+		GID:             uint64(attr.gid),
+		Mode:            os.FileMode(attr.mode),
+		Inode:           int64(attr.id),
+		Mtime:           timevalToTime(attr.mtime),
+		Ctime:           timevalToTime(attr.ctime),
+		CRtime:          timevalToTime(attr.crtime),
+		IsDirectory:     bool(attr.directory),
+		Size:            uint64(attr.size),
+		Chunks:          uint64(attr.chunks),
+		Directories:     uint64(attr.directories),
+		Replicas:        int16(attr.replicas),
+		Stripes:         int16(attr.stripes),
+		RecoveryStripes: int16(attr.recovery_stripes),
+		StripeSize:      int32(attr.stripe_size),
+	}
+}

--- a/src/go/fileinfo_test.go
+++ b/src/go/fileinfo_test.go
@@ -1,0 +1,94 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package qfs
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+func statTestFile(t *testing.T, name string, data []byte, mode os.FileMode) *FileInfo {
+	qfs := initQfs(t)
+	qfs.UmaskSet(0)
+	fpath := path.Join(testDir, name)
+
+	file, err := qfs.OpenFile(fpath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, mode)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	_, err = file.Write(data)
+	if err != nil {
+		t.Fatalf("Failed to write to %v: %v", file, err)
+	}
+	file.Close()
+
+	fi, err := qfs.Stat(fpath)
+	if err != nil {
+		t.Fatalf("Failed to stat file: %v", err)
+	}
+
+	err = qfs.Remove(fpath)
+	if err != nil {
+		t.Fatalf("Failed to remove file: %v", err)
+	}
+
+	return fi
+}
+
+func TestFileInfo_Name(t *testing.T) {
+	name := "test_file_name"
+	fi := statTestFile(t, name, []byte("test data"), 0666)
+
+	if fi.Name() != name {
+		t.Errorf("The name should've been '%s', not '%s'", name, fi.Name())
+	}
+}
+
+func TestFileInfo_Size(t *testing.T) {
+	data := []byte("some general test data")
+	fi := statTestFile(t, "test_name", data, 0666)
+
+	if fi.Size() != int64(len(data)) {
+		t.Errorf("Expected size to be %d, not %d", len(data), fi.Size())
+	}
+}
+
+func TestFileInfo_Mode(t *testing.T) {
+	modes := []os.FileMode{0666, 0777, 0706, 0744}
+
+	for _, mode := range modes {
+		fi := statTestFile(t, "test_name", []byte("test data"), mode)
+		if fi.Mode() != mode {
+			t.Errorf("Expected mode to be %b, not %b", mode, fi.Mode())
+		}
+	}
+}
+
+func TestFileInfo_ModTime(t *testing.T) {
+	fi := statTestFile(t, "test_name", []byte("data"), 0666)
+	actualDuration := time.Since(fi.ModTime())
+
+	// The time difference should be less than 100ms
+	expectedDuration, _ := time.ParseDuration("100ms")
+	if expectedDuration.Nanoseconds() < actualDuration.Nanoseconds() {
+		t.Errorf("Time difference is %v, greater than %v", actualDuration,
+			expectedDuration.Nanoseconds())
+	}
+}

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,0 +1,19 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+module github.com/quantcast/qfs/src/go
+
+require golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -1,0 +1,18 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba h1:nZJIJPGow0Kf9bU9QTc1U6OXbs/7Hu4e+cNv+hxH+Zc=
+golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/src/go/qfs.go
+++ b/src/go/qfs.go
@@ -1,0 +1,270 @@
+// Package qfs interfaces with a instance of the Quantcast File System
+
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package qfs
+
+// #cgo LDFLAGS: -lqfsc
+//
+//#include <stdlib.h>
+//#include <kfs/c/qfs.h>
+//
+import "C"
+import (
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// A Client represents the connection to a QFS instance.
+type Client struct {
+	qfs *C.struct_QFS
+	m   sync.Mutex
+
+	// Set when the connection was closed and the QFS handle has been released.
+	closed bool
+
+	// A pool of buffers to use for reading from files.  This pool beings empty,
+	// but is added to when the Client wants to create a new file but has no
+	// existing buffers in the pool.  This helps minimize initialization of new
+	// buffers and garbage collection.
+	buffers sync.Pool
+}
+
+// Dial conects to QFS at the given address, where address is of the form
+// "host:port".  This returns a QFS Client.
+func Dial(addr string) (*Client, error) {
+	host, portS, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := strconv.Atoi(portS)
+	if err != nil {
+		return nil, err
+	}
+
+	chost := C.CString(host)
+	defer freeCString(chost)
+
+	qfs := C.qfs_connect(chost, C.int(port))
+	if qfs == nil {
+		return nil, fmt.Errorf("unable to connect to QFS at %s", addr)
+	}
+
+	C.qfs_set_default_sparsefilesupport(qfs, true)
+
+	client := &Client{qfs: qfs}
+	runtime.SetFinalizer(client, freeQFSClient)
+
+	return client, nil
+}
+
+// Open a specific file at the specified path.
+func (qfs *Client) Open(name string) (*File, error) {
+	return qfs.OpenFile(name, os.O_RDONLY, 0666)
+}
+
+// OpenFile opens a specific file at the specified path, with the appropriate flags
+// and mode string.  The flags are typical unix `open` flags (see
+// https://golang.org/pkg/io/#pkg-constants).
+func (qfs *Client) OpenFile(name string, flag int, perm os.FileMode) (*File, error) {
+	cname := C.CString(name)
+	defer freeCString(cname)
+
+	fd := C.qfs_open_file(qfs.qfs, cname, C.int(flag),
+		C.uint16_t(perm), nil)
+	if fd < 0 {
+		return nil, errFromQfs(fd)
+	}
+
+	return newFile(qfs, fd, name), nil
+}
+
+// Close the Client and release the QFS handle.
+func (qfs *Client) Close() {
+	qfs.m.Lock()
+	defer qfs.m.Unlock()
+
+	if qfs.closed {
+		return
+	}
+	qfs.closed = true
+
+	C.qfs_release(qfs.qfs)
+}
+
+// Stat gets the FileInfo type for a given file.
+func (qfs *Client) Stat(path string) (*FileInfo, error) {
+	var attr C.struct_qfs_attr
+
+	cpath := C.CString(path)
+	defer freeCString(cpath)
+
+	res := C.qfs_stat(qfs.qfs, cpath, &attr)
+
+	if res < 0 {
+		return nil, errFromQfs(res)
+	}
+
+	return newFileInfo(attr), nil
+}
+
+// This is a helper method that calls stat, and derives information from the
+// call to facilitate other public methods.  It returns a FileInfo struct,
+// a bool indicated if or if not the file exists, and optionally an error.
+func (qfs *Client) existsWithInfo(path string) (*FileInfo, bool, error) {
+	val, err := qfs.Stat(path)
+
+	// Return true if the error is nil, or false if file not found
+	if err == nil {
+		return val, true, nil
+	} else if IsQfsErrorCode(err, unix.ENOENT) {
+		return nil, false, nil
+	}
+
+	return nil, false, err // There must have been an error
+}
+
+// Exists tests if a file or directory at the specified path exists.
+func (qfs *Client) Exists(path string) (bool, error) {
+	_, exists, err := qfs.existsWithInfo(path)
+	return exists, err
+}
+
+// IsFile tests if the file at the specified path exists and is a file.
+func (qfs *Client) IsFile(path string) (bool, error) {
+	val, exists, err := qfs.existsWithInfo(path)
+	if err != nil {
+		return false, err
+	} else if !exists {
+		return false, nil
+	}
+	return exists && !val.IsDir(), nil
+}
+
+// IsDirectory tests if the file at the specified path exists and is a directory.
+func (qfs *Client) IsDirectory(path string) (bool, error) {
+	val, exists, err := qfs.existsWithInfo(path)
+	if err != nil {
+		return false, err
+	} else if !exists {
+		return false, nil
+	}
+	return exists && val.IsDir(), nil
+}
+
+// Mkdir creates a new directory with the specified name and permission bits.
+func (qfs *Client) Mkdir(path string, perm os.FileMode) error {
+	cpath := C.CString(path)
+	defer freeCString(cpath)
+
+	res := C.qfs_mkdir(qfs.qfs, cpath, C.mode_t(perm))
+	if res < 0 {
+		return errFromQfs(res)
+	}
+	return nil
+}
+
+// MkdirAll creates a directory with the specified name, and any parents
+// necessary.  All of the directories have the specified permissions.
+func (qfs *Client) MkdirAll(path string, perm os.FileMode) error {
+	cpath := C.CString(path)
+	defer freeCString(cpath)
+
+	res := C.qfs_mkdirs(qfs.qfs, cpath, C.mode_t(perm))
+	if res < 0 {
+		return errFromQfs(res)
+	}
+	return nil
+}
+
+// Remove removes the specified file or directory.
+func (qfs *Client) Remove(path string) error {
+	isDir, err := qfs.IsDirectory(path)
+	if err != nil {
+		return err
+	}
+
+	cpath := C.CString(path)
+	defer freeCString(cpath)
+
+	var res C.int
+	if isDir {
+		res = C.qfs_rmdir(qfs.qfs, cpath)
+	} else {
+		res = C.qfs_remove(qfs.qfs, cpath)
+	}
+
+	if res < 0 {
+		return errFromQfs(res)
+	}
+	return nil
+}
+
+// RemoveAll removes the specified path, and if it is a directory, removes
+// all the children it contains.
+func (qfs *Client) RemoveAll(path string) error {
+	isDir, err := qfs.IsDirectory(path)
+	if err != nil {
+		return err
+	}
+
+	cpath := C.CString(path)
+	defer freeCString(cpath)
+
+	var res C.int
+	if isDir {
+		res = C.qfs_rmdirs(qfs.qfs, cpath)
+	} else {
+		res = C.qfs_remove(qfs.qfs, cpath)
+	}
+
+	if res < 0 {
+		return errFromQfs(res)
+	}
+	return nil
+}
+
+// UmaskSet sets the umask for this Client.
+func (qfs *Client) UmaskSet(perm os.FileMode) {
+	C.qfs_set_umask(qfs.qfs, C.mode_t(perm))
+}
+
+// UmaskGet gets the current umask for this Client.
+func (qfs *Client) UmaskGet() (os.FileMode, error) {
+	res := C.qfs_get_umask(qfs.qfs)
+	if int(res) < 0 {
+		return 0, errFromQfs(C.int(res))
+	}
+	return os.FileMode(res), nil
+}
+
+// free frees the memory allocated by a C.CString.  Its probably best to just
+// call this immediately after allocation with a "defer" statement
+func freeCString(cs *C.char) {
+	C.free(unsafe.Pointer(cs))
+}
+
+func freeQFSClient(qfs *Client) {
+	qfs.Close()
+}

--- a/src/go/qfs_test.go
+++ b/src/go/qfs_test.go
@@ -1,0 +1,372 @@
+// Copyright 2016-2017 Quantcast Corporation. All rights reserved.
+//
+// This file is part of Quantcast File System.
+//
+// Licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package qfs
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	badPath = "not/a/real/path"
+	testDir = "/go-qfs-test"
+)
+
+var addr string
+
+func init() {
+	flag.StringVar(&addr, "qfs.addr", "localhost:10000",
+		"Host and Port of metaserver to be used for testing")
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	qfs, err := Dial(addr)
+	if err != nil {
+		log.Fatalf("Failed to connect to QFS")
+	}
+
+	if exist, err := qfs.Exists(testDir); exist {
+		if err != nil {
+			log.Fatalf("Failed to check if the test directory %s exists: %v",
+				testDir, err)
+		}
+		err = qfs.RemoveAll(testDir)
+		if err != nil {
+			log.Fatalf("Failed to delete %s: %v", testDir, err)
+		}
+	}
+
+	err = qfs.Mkdir(testDir, 0766)
+	if err != nil {
+		log.Fatalf("Couldn't make directory %s: %v", testDir, err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func initQfs(t *testing.T) *Client {
+	qfs, err := Dial(addr)
+	if err != nil {
+		t.Fatalf("Failed opening a connection to QFS: %v", err)
+	}
+	return qfs
+}
+
+func TestIntegration(t *testing.T) {
+	qfs, err := Dial(addr)
+
+	if err != nil {
+		t.Fatalf("could not connect to qfs: %v", err)
+	}
+	defer qfs.Close()
+
+	root, err := qfs.Open("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	fi, err := root.Stat()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isdir, err := qfs.IsDirectory("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exists, err := qfs.Exists("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() || !isdir || !exists {
+		t.Fatalf("expected root to be a directory")
+	}
+
+	// Test a directory that shouldn't exist
+	funcs := [](func(string) (bool, error)){qfs.IsDirectory, qfs.IsFile, qfs.Exists}
+	fakeDir := "not a directory"
+	for _, existFunc := range funcs {
+		res, err := existFunc(fakeDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res {
+			t.Errorf("The file '%s' should not exist", fakeDir)
+		}
+	}
+
+	fis, err := root.Readdir(-1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, fi := range fis {
+		t.Log("fi", fi.Name())
+	}
+
+}
+
+func TestFileNotFound(t *testing.T) {
+	qfs, err := Dial(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = qfs.Stat(badPath)
+	if !IsQfsErrorCode(err, unix.ENOENT) {
+		t.Errorf("The error should have been ENOENT, not: %v", err)
+	}
+
+	_, err = qfs.Open(badPath)
+	if !IsQfsErrorCode(err, unix.ENOENT) {
+		t.Errorf("The error should have been ENOENT, not: %v", err)
+	}
+}
+
+func TestDial(t *testing.T) {
+	_, err := Dial("not_an_address")
+	if err == nil {
+		t.Errorf("Dialing an address without a port should throw an error")
+	}
+
+	_, err = Dial("address:not_port")
+	if err == nil {
+		t.Errorf("Entering a non-numeric port should throw an error")
+	}
+
+	_, err = Dial(addr)
+	if err != nil {
+		t.Errorf("QFS didn't connect: %v", err)
+	}
+}
+
+func TestOpen(t *testing.T) {
+	qfs := initQfs(t)
+
+	_, err := qfs.Open(badPath)
+	if !IsQfsErrorCode(err, unix.ENOENT) {
+		t.Errorf("Opening a nonexistant file should throw ENOENT, not: %v", err)
+	}
+
+	_, err = qfs.Open("/")
+	if err != nil {
+		t.Errorf("Failed to open the file: %v", err)
+	}
+}
+
+func ExampleClient_Open() {
+	qfs, err := Dial(addr)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	_, err = qfs.Open("/")
+	if err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+}
+
+func TestClose(t *testing.T) {
+	qfs := initQfs(t)
+
+	qfs.Close()
+	if !qfs.closed {
+		t.Error("The QFS handle didn't say its closed")
+	}
+
+	qfs.Close()
+	if !qfs.closed {
+		t.Error("The QFS handle didn't say its closed")
+	}
+}
+
+func ExampleClient_Close() {
+	qfs, err := Dial(addr)
+	if err != nil {
+		fmt.Println(err)
+	}
+	qfs.Close()
+	// Output:
+}
+
+func TestStat(t *testing.T) {
+	qfs := initQfs(t)
+
+	_, err := qfs.Stat(badPath)
+	if err == nil {
+		t.Error("Stat didn't return an error on a nonexistant file")
+	}
+
+	_, err = qfs.Stat("/")
+	if err != nil {
+		t.Errorf("Stat should have succeeded: %v", err)
+	}
+}
+
+func ExampleClient_Stat() {
+	qfs, err := Dial(addr)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fileInfo, err := qfs.Stat("/")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Print(fileInfo.Name())
+	// Output: /
+}
+
+func TestExists(t *testing.T) {
+	qfs := initQfs(t)
+
+	exists, err := qfs.Exists(badPath)
+	if err != nil {
+		t.Errorf("Exists should not have returned an error: %v", err)
+	}
+	if exists {
+		t.Error("Calling Exists on a bad path should return false")
+	}
+
+	exists, err = qfs.Exists("/")
+	if err != nil {
+		t.Errorf("Exists should not have returned an error: %v", err)
+	}
+	if !exists {
+		t.Error("Calling Exists on the root should return true")
+	}
+}
+
+func TestIsFile(t *testing.T) {
+	qfs := initQfs(t)
+
+	isFile, err := qfs.IsFile(badPath)
+	if err != nil {
+		t.Errorf("IsFile should not have returned an error: %v", err)
+	}
+	if isFile {
+		t.Error("A bad path isn't a file")
+	}
+
+	isFile, err = qfs.IsFile("/")
+	if err != nil {
+		t.Errorf("IsFile should not have returned an error: %v", err)
+	}
+	if isFile {
+		t.Error("The root is not a file")
+	}
+}
+
+func TestIsDirectory(t *testing.T) {
+	qfs := initQfs(t)
+
+	isDir, err := qfs.IsDirectory(badPath)
+	if err != nil {
+		t.Errorf("IsDirectory should not have returned an error: %v", err)
+	}
+	if isDir {
+		t.Error("A bad path isn't a directory")
+	}
+
+	isDir, err = qfs.IsDirectory("/")
+	if err != nil {
+		t.Errorf("IsDirectory should not have returned an error: %v", err)
+	}
+	if !isDir {
+		t.Error("The root should be a directory")
+	}
+}
+
+func TestMkdirRmdir(t *testing.T) {
+	qfs := initQfs(t)
+
+	path := "/test_dir"
+	err := qfs.Mkdir(path, 0666)
+	if err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+
+	if res, err := qfs.IsDirectory(path); !res || err != nil {
+		t.Errorf("Failed to create directory %s, exists: %v, err: %v",
+			path, res, err)
+	}
+
+	err = qfs.Remove(path)
+	if err != nil {
+		t.Fatalf("Failed to remove directory: %v", err)
+	}
+
+	if res, err := qfs.IsDirectory(path); res || err != nil {
+		t.Errorf("Failed to remove directory %s, exists: %v, err: %v",
+			path, res, err)
+	}
+}
+
+func TestMkdirAllRemoveAll(t *testing.T) {
+	qfs := initQfs(t)
+
+	path := "/very/deep/test/directory"
+	err := qfs.MkdirAll(path, 0766)
+	if err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+
+	if res, err := qfs.IsDirectory(path); !res || err != nil {
+		t.Errorf("Failed to create directory %s, exists: %v, err: %v",
+			path, res, err)
+	}
+
+	err = qfs.RemoveAll(path)
+	if err != nil {
+		t.Fatalf("Failed to remove directory: %v", err)
+	}
+
+	if res, err := qfs.IsDirectory(path); res || err != nil {
+		t.Errorf("Failed to remove directory %s, exists: %v, err: %v",
+			path, res, err)
+	}
+}
+
+func TestUmask(t *testing.T) {
+	qfs := initQfs(t)
+
+	umasks := []os.FileMode{0666, 0777, 0743, 0611}
+	for _, umask := range umasks {
+		qfs.UmaskSet(umask)
+
+		actualUmask, err := qfs.UmaskGet()
+		if err != nil {
+			t.Fatalf("Got an error getting a umask: %v", err)
+		}
+		if umask != actualUmask {
+			t.Errorf("Umasks did not match\nExpected: %v\nActual:%v", umask,
+				actualUmask)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This adds Go bindings for the QFS C API.  It implements some of the available functions, specifically those which have been used for internal services within Quantcast.  There are definitely some missing, but this library may definitely be useful to others even in it's current form.

All the code has been previously reviewed and approved inside Quantcast ([OPENSOURCE-95](https://bugs.corp.qc/browse/OPENSOURCE-95)). I'm removing the Git history to reduce the change of exposing confidential information, but this library was implemented by the following people:
* Steve Day
* Eric Culp
* Noah Goldman

## Testing Done

This is currently being used in production at Quantcast.

@kstinsonqc @mckurt 