### PR TITLE
examples: fix sample setup python script to pass the right path for c…

### DIFF
--- a/examples/sampleservers/sample_setup.py
+++ b/examples/sampleservers/sample_setup.py
@@ -677,7 +677,7 @@ def start_servers(config, whichServers, createNewFsFlag, authFlag):
         for section in config.sections():
             if section.startswith('chunkserver'):
                 chunkRunDir = config.get(section, 'rundir')
-                kill_running_program_pid(chunkRunDir, chunkRunDir)
+                kill_running_program_pid(Globals.CHUNKSERVER, chunkRunDir)
                 if chunkRunDir:
                     chunkConf = chunkRunDir + '/conf/ChunkServer.prp'
                     chunkLog  = chunkRunDir + '/ChunkServer.log'


### PR DESCRIPTION
…hunkserver binary

This fixes a bug that prevents sample servers python script from launching chunkservers. kill_running_program_pid expects the chunkserver binary path as the first argument.

